### PR TITLE
Added an error logger for failed HTTP requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,101 +18,56 @@
       <artifactId>vertx-web</artifactId>
       <version>3.2.1</version>
     </dependency>
-
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-mongo-client</artifactId>
-      <version>3.2.1</version>
-    </dependency>
-
     <dependency>
       <groupId>io.reactivex.rxjava2</groupId>
       <artifactId>rxjava</artifactId>
       <version>2.0.8</version>
     </dependency>
-
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>21.0</version>
     </dependency>
-
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-jdbc</artifactId>
       <version>2.0.6</version>
     </dependency>
-
     <dependency>
       <groupId>com.github.akarnokd</groupId>
       <artifactId>rxjava2-extensions</artifactId>
       <version>0.17.0</version>
     </dependency>
-
-    <!-- Test dependencies -->
-
-
-
-    <dependency>
-      <groupId>org.neo4j.driver</groupId>
-      <artifactId>neo4j-java-driver</artifactId>
-      <version>1.2.0</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.neo4j.driver</groupId>
-      <artifactId>neo4j-java-driver</artifactId>
-      <version>1.2.0</version>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-
-
     <dependency>
       <groupId>redis.clients</groupId>
       <artifactId>jedis</artifactId>
       <version>2.9.0</version>
     </dependency>
-
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
       <version>5.1.39</version>
     </dependency>
-
     <dependency>
       <groupId>commons-dbcp</groupId>
       <artifactId>commons-dbcp</artifactId>
       <version>1.4</version>
     </dependency>
-
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>4.5.3</version>
     </dependency>
-
     <dependency>
-      <groupId>org.quartz-scheduler</groupId>
-      <artifactId>quartz</artifactId>
-      <version>2.2.1</version>
+        <groupId>com.google.inject</groupId>
+        <artifactId>guice</artifactId>
+        <version>4.1.0</version>
     </dependency>
     <dependency>
-      <groupId>org.quartz-scheduler</groupId>
-      <artifactId>quartz-jobs</artifactId>
-      <version>2.2.1</version>
+        <groupId>commons-beanutils</groupId>
+        <artifactId>commons-beanutils</artifactId>
+        <version>1.9.2</version>
     </dependency>
-      <dependency>
-          <groupId>com.google.inject</groupId>
-          <artifactId>guice</artifactId>
-          <version>4.1.0</version>
-      </dependency>
-      <dependency>
-          <groupId>commons-beanutils</groupId>
-          <artifactId>commons-beanutils</artifactId>
-          <version>1.9.2</version>
-      </dependency>
-    <!-- For the tests -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -125,7 +80,6 @@
       <version>3.2.1</version>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
@@ -141,19 +95,16 @@
       <artifactId>rest-assured</artifactId>
       <version>3.0.2</version>
     </dependency>
-
     <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
       <version>20160810</version>
     </dependency>
-
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
       <version>2.2.0</version>
     </dependency>
-
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path-assert</artifactId>
@@ -163,14 +114,6 @@
 
 
   <build>
-    <!-- Need to enable the filtering of the src/test/resources to inject the random port -->
-    <testResources>
-      <testResource>
-        <directory>src/test/resources</directory>
-        <filtering>true</filtering>
-      </testResource>
-    </testResources>
-
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -207,26 +150,6 @@
             <goals>
               <goal>report</goal>
             </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <!-- Pick an unused random port, the selected port is set into the "http.port" variable -->
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <version>1.9.1</version>
-        <executions>
-          <execution>
-            <id>reserve-network-port</id>
-            <goals>
-              <goal>reserve-network-port</goal>
-            </goals>
-            <phase>process-sources</phase>
-            <configuration>
-              <portNames>
-                <portName>http.port</portName>
-              </portNames>
-            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/src/main/java/com/atypon/wayf/dao/ErrorLoggerDao.java
+++ b/src/main/java/com/atypon/wayf/dao/ErrorLoggerDao.java
@@ -14,23 +14,12 @@
  * limitations under the License.
  */
 
-package com.atypon.wayf.guice;
+package com.atypon.wayf.dao;
 
-import com.google.inject.AbstractModule;
-import org.junit.ClassRule;
-import org.neo4j.driver.v1.Driver;
-import org.neo4j.driver.v1.util.TestNeo4j;
+import com.atypon.wayf.data.ErrorLogEntry;
+import io.reactivex.Completable;
 
-public class TestGuiceModule extends AbstractModule {
+public interface ErrorLoggerDao {
 
-    @ClassRule
-    public TestNeo4j neo4j;
-    public TestGuiceModule(TestNeo4j neo4j) {
-        this.neo4j = neo4j;
-    }
-
-    @Override
-    protected void configure() {
-        bind(Driver.class).toProvider(() -> neo4j.driver());
-    }
+    Completable logError(ErrorLogEntry logEntry);
 }

--- a/src/main/java/com/atypon/wayf/dao/impl/ErrorLoggerDaoDbImpl.java
+++ b/src/main/java/com/atypon/wayf/dao/impl/ErrorLoggerDaoDbImpl.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 Atypon Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atypon.wayf.dao.impl;
+
+import com.atypon.wayf.dao.ErrorLoggerDao;
+import com.atypon.wayf.data.ErrorLogEntry;
+import com.atypon.wayf.database.DbExecutor;
+import com.atypon.wayf.reactivex.DaoPolicies;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.google.inject.name.Named;
+import io.reactivex.Completable;
+
+@Singleton
+public class ErrorLoggerDaoDbImpl implements ErrorLoggerDao {
+
+    @Inject
+    @Named("error-logger.dao.db.create")
+    private String create;
+
+    @Inject
+    private DbExecutor dbExecutor;
+
+    @Override
+    public Completable logError(ErrorLogEntry logEntry) {
+        return dbExecutor.executeUpdate(create, logEntry).compose((single) -> DaoPolicies.applySingle(single)).toCompletable();
+    }
+}

--- a/src/main/java/com/atypon/wayf/data/ErrorLogEntry.java
+++ b/src/main/java/com/atypon/wayf/data/ErrorLogEntry.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2017 Atypon Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atypon.wayf.data;
+
+import java.util.Date;
+
+public class ErrorLogEntry {
+    private Long id;
+    private String authenticatedParty;
+    private String deviceGlobalId;
+    private String httpMethod;
+    private String requestUrl;
+    private String headers;
+    private String callerIp;
+    private String serverIp;
+    private int responseCode;
+    private String exceptionType;
+    private String exceptionMessage;
+    private String exceptionStacktrace;
+    private Date errorDate;
+    private Date createdDate;
+    private Date modifiedDate;
+
+    public ErrorLogEntry() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public ErrorLogEntry setId(Long id) {
+        this.id = id;
+        return this;
+    }
+    public String getAuthenticatedParty() {
+        return authenticatedParty;
+    }
+
+    public ErrorLogEntry setAuthenticatedParty(String authenticatedParty) {
+        this.authenticatedParty = authenticatedParty;
+        return this;
+    }
+
+    public String getDeviceGlobalId() {
+        return deviceGlobalId;
+    }
+
+    public ErrorLogEntry setDeviceGlobalId(String deviceGlobalId) {
+        this.deviceGlobalId = deviceGlobalId;
+        return this;
+    }
+
+    public String getHttpMethod() {
+        return httpMethod;
+    }
+
+    public ErrorLogEntry setHttpMethod(String httpMethod) {
+        this.httpMethod = httpMethod;
+        return this;
+    }
+
+    public String getRequestUrl() {
+        return requestUrl;
+    }
+
+    public ErrorLogEntry setRequestUrl(String requestUrl) {
+        this.requestUrl = requestUrl;
+        return this;
+    }
+
+    public String getHeaders() {
+        return headers;
+    }
+
+    public ErrorLogEntry setHeaders(String headers) {
+        this.headers = headers;
+        return this;
+    }
+
+    public String getCallerIp() {
+        return callerIp;
+    }
+
+    public ErrorLogEntry setCallerIp(String callerIp) {
+        this.callerIp = callerIp;
+        return this;
+    }
+
+    public String getServerIp() {
+        return serverIp;
+    }
+
+    public ErrorLogEntry setServerIp(String serverIp) {
+        this.serverIp = serverIp;
+        return this;
+    }
+
+    public int getResponseCode() {
+        return responseCode;
+    }
+
+    public ErrorLogEntry setResponseCode(int responseCode) {
+        this.responseCode = responseCode;
+        return this;
+    }
+
+    public String getExceptionType() {
+        return exceptionType;
+    }
+
+    public ErrorLogEntry setExceptionType(String exceptionType) {
+        this.exceptionType = exceptionType;
+        return this;
+    }
+
+    public String getExceptionMessage() {
+        return exceptionMessage;
+    }
+
+    public ErrorLogEntry setExceptionMessage(String exceptionMessage) {
+        this.exceptionMessage = exceptionMessage;
+        return this;
+    }
+
+    public String getExceptionStacktrace() {
+        return exceptionStacktrace;
+    }
+
+    public ErrorLogEntry setExceptionStacktrace(String exceptionStacktrace) {
+        this.exceptionStacktrace = exceptionStacktrace;
+        return this;
+    }
+
+    public Date getErrorDate() {
+        return errorDate;
+    }
+
+    public ErrorLogEntry setErrorDate(Date errorDate) {
+        this.errorDate = errorDate;
+        return this;
+    }
+
+    public Date getCreatedDate() {
+        return createdDate;
+    }
+
+    public ErrorLogEntry setCreatedDate(Date createdDate) {
+        this.createdDate = createdDate;
+        return this;
+    }
+
+    public Date getModifiedDate() {
+        return modifiedDate;
+    }
+
+    public ErrorLogEntry setModifiedDate(Date modifiedDate) {
+        this.modifiedDate = modifiedDate;
+        return this;
+    }
+}

--- a/src/main/java/com/atypon/wayf/facade/ErrorLoggerFacade.java
+++ b/src/main/java/com/atypon/wayf/facade/ErrorLoggerFacade.java
@@ -14,21 +14,10 @@
  * limitations under the License.
  */
 
-package com.atypon.wayf.reactivex;
+package com.atypon.wayf.facade;
 
-import io.reactivex.plugins.RxJavaPlugins;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.reactivex.Completable;
 
-/**
- * A class to manage any configurations required for the ReactiveX library.
- */
-public class WayfReactivexConfig {
-    private static final Logger LOG = LoggerFactory.getLogger(WayfReactivexConfig.class);
-
-    public static void initializePlugins() {
-        LOG.debug("Initializing ReactiveX plugins");
-
-        RxJavaPlugins.setScheduleHandler((runnable) -> new WayfRunnable(runnable));
-    }
+public interface ErrorLoggerFacade {
+    Completable buildAndLogError(int statusCode, Throwable t);
 }

--- a/src/main/java/com/atypon/wayf/facade/impl/ErrorLoggerFacadeImpl.java
+++ b/src/main/java/com/atypon/wayf/facade/impl/ErrorLoggerFacadeImpl.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2017 Atypon Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atypon.wayf.facade.impl;
+
+import com.atypon.wayf.dao.ErrorLoggerDao;
+import com.atypon.wayf.data.Authenticatable;
+import com.atypon.wayf.data.ErrorLogEntry;
+import com.atypon.wayf.facade.ErrorLoggerFacade;
+import com.atypon.wayf.request.RequestContext;
+import com.atypon.wayf.request.RequestContextAccessor;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import io.reactivex.Completable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.net.InetAddress;
+import java.util.Date;
+import java.util.List;
+
+@Singleton
+public class ErrorLoggerFacadeImpl implements ErrorLoggerFacade {
+    private static final Logger LOG = LoggerFactory.getLogger(ErrorLoggerFacadeImpl.class);
+
+    @Inject
+    private ErrorLoggerDao errorLoggerDao;
+
+    private String ipAddress;
+
+    public ErrorLoggerFacadeImpl() {
+        try {
+            InetAddress ipAddr = InetAddress.getLocalHost();
+            ipAddress = ipAddr.getHostAddress();
+        } catch (Exception e) {
+            LOG.error("Could not get IP address of server", e);
+        }
+    }
+
+    public Completable buildAndLogError(int statusCode, Throwable t) {
+        ErrorLogEntry logEntry = new ErrorLogEntry();
+        logEntry.setResponseCode(statusCode);
+
+        logEntry.setExceptionType(t.getClass().getCanonicalName());
+        logEntry.setExceptionMessage(t.getMessage());
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        PrintStream printStream = new PrintStream(outputStream);
+        t.printStackTrace(printStream);
+
+        try {
+            logEntry.setExceptionStacktrace(outputStream.toString("utf-8"));
+        } catch (Exception e) {
+            LOG.error("Could not get stacktrace", e);
+        }
+
+        logEntry.setErrorDate(new Date());
+
+        RequestContext requestContext = RequestContextAccessor.get();
+
+        logEntry.setDeviceGlobalId(requestContext.getDeviceId());
+
+        Authenticatable authenticated = requestContext.getAuthenticated();
+        if(authenticated != null) {
+            logEntry.setAuthenticatedParty(authenticated.getType() + "-" + authenticated.getId());
+        }
+
+        logEntry.setHeaders(requestContext.getHeaders().toString());
+        List<String> forwardedFor = requestContext.getHeaders().get("X-Forwarded-For");
+        if (forwardedFor != null && !forwardedFor.isEmpty()) {
+            logEntry.setCallerIp(forwardedFor.get(0).toString());
+        }
+        logEntry.setServerIp(ipAddress);
+        logEntry.setHttpMethod(requestContext.getHttpMethod());
+        logEntry.setRequestUrl(requestContext.getRequestUrl());
+
+        return errorLoggerDao.logError(logEntry);
+    }
+}

--- a/src/main/java/com/atypon/wayf/facade/impl/ErrorLoggerFacadeImpl.java
+++ b/src/main/java/com/atypon/wayf/facade/impl/ErrorLoggerFacadeImpl.java
@@ -56,6 +56,10 @@ public class ErrorLoggerFacadeImpl implements ErrorLoggerFacade {
         }
     }
 
+    public void setErrorLoggerDao(ErrorLoggerDao errorLoggerDao) {
+        this.errorLoggerDao = errorLoggerDao;
+    }
+
     public Completable buildAndLogError(int statusCode, Throwable t) {
         ErrorLogEntry logEntry = new ErrorLogEntry();
         logEntry.setResponseCode(statusCode);
@@ -103,6 +107,6 @@ public class ErrorLoggerFacadeImpl implements ErrorLoggerFacade {
             return null;
         }
 
-        return string.substring(0, length);
+        return (string.length() > length)? string.substring(0, length) : string;
     }
 }

--- a/src/main/java/com/atypon/wayf/guice/WayfGuiceModule.java
+++ b/src/main/java/com/atypon/wayf/guice/WayfGuiceModule.java
@@ -79,6 +79,7 @@ public class WayfGuiceModule extends AbstractModule {
             properties.load(classLoader.getResourceAsStream("dao/oauth-entity-dao-db.properties"));
             properties.load(classLoader.getResourceAsStream("dao/device-identity-provider-blacklist-dao-db.properties"));
             properties.load(classLoader.getResourceAsStream("dao/authentication-dao-db.properties"));
+            properties.load(classLoader.getResourceAsStream("dao/error-logger-dao-db.properties"));
 
             Names.bindProperties(binder(), properties);
 
@@ -99,6 +100,9 @@ public class WayfGuiceModule extends AbstractModule {
             bind(PublisherDao.class).to(PublisherDaoDbImpl.class);
 
             bind(IdentityProviderFacade.class).to(IdentityProviderFacadeImpl.class);
+
+            bind(ErrorLoggerFacade.class).to(ErrorLoggerFacadeImpl.class);
+            bind(ErrorLoggerDao.class).to(ErrorLoggerDaoDbImpl.class);
 
             bind(new TypeLiteral<InflationPolicyParser<String>>(){}).to(InflationPolicyParserQueryParamImpl.class);
 

--- a/src/main/java/com/atypon/wayf/request/RequestContext.java
+++ b/src/main/java/com/atypon/wayf/request/RequestContext.java
@@ -20,6 +20,9 @@ import com.atypon.wayf.data.Authenticatable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
+import java.util.Map;
+
 public class RequestContext {
     private static final Logger LOG = LoggerFactory.getLogger(RequestContext.class);
 
@@ -29,16 +32,56 @@ public class RequestContext {
     private Integer limit = DEFAULT_LIMIT;
     private Integer offset = DEFAULT_OFFSET;
 
+    private String apiToken;
+    private String httpMethod;
+    private String requestBody;
     private String userAgent;
     private String deviceId;
     private String requestUrl;
     private String requestUri;
+    private Map<String, List<String>> headers;
 
     private Authenticatable authenticated;
 
     private Boolean hasAnotherDbPage = Boolean.FALSE;
 
     public RequestContext() {
+    }
+
+    public String getApiToken() {
+        return apiToken;
+    }
+
+    public RequestContext setApiToken(String apiToken) {
+        this.apiToken = apiToken;
+        return this;
+    }
+
+    public String getHttpMethod() {
+        return httpMethod;
+    }
+
+    public RequestContext setHttpMethod(String httpMethod) {
+        this.httpMethod = httpMethod;
+        return this;
+    }
+
+    public String getRequestBody() {
+        return requestBody;
+    }
+
+    public RequestContext setRequestBody(String requestBody) {
+        this.requestBody = requestBody;
+        return this;
+    }
+
+    public Map<String, List<String>> getHeaders() {
+        return headers;
+    }
+
+    public RequestContext setHeaders(Map<String, List<String>> headers) {
+        this.headers = headers;
+        return this;
     }
 
     public String getRequestUrl() {

--- a/src/main/java/com/atypon/wayf/request/ResponseWriter.java
+++ b/src/main/java/com/atypon/wayf/request/ResponseWriter.java
@@ -52,7 +52,7 @@ public class ResponseWriter {
     private static final String CONTENT_TYPE_VALUE = "application/json; charset=utf-8";
 
     @Inject
-    private ErrorLoggerFacade errorLoggerFacade;
+    protected ErrorLoggerFacade errorLoggerFacade;
 
     public ResponseWriter() {
         Json.prettyMapper.setDateFormat(DATE_FORMAT);

--- a/src/main/java/com/atypon/wayf/verticle/WayfVerticle.java
+++ b/src/main/java/com/atypon/wayf/verticle/WayfVerticle.java
@@ -52,6 +52,9 @@ public class WayfVerticle extends AbstractVerticle {
     private PublisherRouting publisherRouting;
 
     @Inject
+    private ResponseWriter responseWriter;
+
+    @Inject
     @Named("wayf.port")
     private Integer wayfPort;
 
@@ -77,7 +80,7 @@ public class WayfVerticle extends AbstractVerticle {
 
         LOG.debug("Adding default error handler to routes");
         for (Route route : router.getRoutes()) {
-            route.failureHandler((rc) -> ResponseWriter.buildFailure(rc));
+            route.failureHandler((rc) -> responseWriter.buildFailure(rc));
             LOG.debug("Found path {}", route);
         }
 

--- a/src/main/java/com/atypon/wayf/verticle/routing/DeviceRoutingProvider.java
+++ b/src/main/java/com/atypon/wayf/verticle/routing/DeviceRoutingProvider.java
@@ -46,6 +46,9 @@ public class DeviceRoutingProvider implements RoutingProvider {
     private static final String ADD_DEVICE_PUBLISHER_RELATIONSHIP = "/1/device/:localId";
 
     @Inject
+    private ResponseWriter responseWriter;
+
+    @Inject
     private DeviceFacade deviceFacade;
 
     @Inject
@@ -63,7 +66,6 @@ public class DeviceRoutingProvider implements RoutingProvider {
         router.get(FILTER_DEVICE).handler(handlerFactory.observable((rc) -> filterDevice(rc)));
         router.patch(ADD_DEVICE_PUBLISHER_RELATIONSHIP).handler(handlerFactory.single((rc) -> createPublisherDeviceRelationship(rc)));
     }
-
 
     public Single<Device> readDevice(RoutingContext routingContext) {
         LOG.debug("Received read Device request");
@@ -89,7 +91,7 @@ public class DeviceRoutingProvider implements RoutingProvider {
         return deviceFacade.createOrUpdateForPublisher(localId)
                 .map((device) -> {
                     String globalId = device.getGlobalId();
-                    ResponseWriter.setDeviceIdHeader(routingContext, globalId);
+                    responseWriter.setDeviceIdHeader(routingContext, globalId);
                     device.setGlobalId(null);
                     return device;
                 });

--- a/src/main/resources/dao/error-logger-dao-db.properties
+++ b/src/main/resources/dao/error-logger-dao-db.properties
@@ -1,0 +1,24 @@
+#
+# Copyright 2017 Atypon Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+error-logger.dao.db.create = \
+INSERT INTO wayf.error_log \
+    (authenticated_party, device_global_id, http_method, request_url, \
+            headers, caller_ip, server_ip, response_code, exception_type, \
+            exception_message, exception_stacktrace, error_date) \
+        VALUES (:authenticatedParty, :deviceGlobalId, :httpMethod, :requestUrl, \
+                :headers, :callerIp, :serverIp, :responseCode, :exceptionType, \
+                :exceptionMessage, :exceptionStacktrace, :errorDate);

--- a/src/test/java/com/atypon/wayf/dao/impl/ErrorLoggerDaoMockImpl.java
+++ b/src/test/java/com/atypon/wayf/dao/impl/ErrorLoggerDaoMockImpl.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 Atypon Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atypon.wayf.dao.impl;
+
+import com.atypon.wayf.dao.ErrorLoggerDao;
+import com.atypon.wayf.data.ErrorLogEntry;
+import io.reactivex.Completable;
+
+public class ErrorLoggerDaoMockImpl implements ErrorLoggerDao {
+
+    private ErrorLogEntry lastLoggedError;
+
+    public ErrorLogEntry getLastLoggedError() {
+        return lastLoggedError;
+    }
+
+    @Override
+    public Completable logError(ErrorLogEntry logEntry) {
+        this.lastLoggedError = logEntry;
+        return Completable.complete();
+    }
+}

--- a/src/test/java/com/atypon/wayf/dao/impl/ErrorLoggerDaoTest.java
+++ b/src/test/java/com/atypon/wayf/dao/impl/ErrorLoggerDaoTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 Atypon Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atypon.wayf.dao.impl;
+
+import com.atypon.wayf.dao.ErrorLoggerDao;
+import com.atypon.wayf.data.ErrorLogEntry;
+import com.atypon.wayf.data.ServiceException;
+import com.atypon.wayf.guice.WayfGuiceModule;
+import com.atypon.wayf.reactivex.WayfReactivexConfig;
+import com.atypon.wayf.request.RequestContext;
+import com.atypon.wayf.request.RequestContextAccessor;
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import io.vertx.core.http.HttpMethod;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Date;
+import java.util.UUID;
+
+import static junit.framework.Assert.fail;
+
+public class ErrorLoggerDaoTest {
+
+    @Inject
+    private ErrorLoggerDao errorLoggerDao;
+
+    @Before
+    public void setup() {
+        Guice.createInjector(new WayfGuiceModule()).injectMembers(this);
+
+        WayfReactivexConfig.initializePlugins();
+        RequestContextAccessor.set(new RequestContext());
+    }
+
+    @Test
+    public void testDbWrite() {
+        ErrorLogEntry logEntry = new ErrorLogEntry();
+        logEntry.setHttpMethod(HttpMethod.POST.toString());
+        logEntry.setRequestUrl("test-request-url");
+        logEntry.setServerIp("127.0.0.1");
+        logEntry.setCallerIp("1227.0.01");
+        logEntry.setResponseCode(500);
+        logEntry.setAuthenticatedParty("PUBLISHER-123");
+        logEntry.setDeviceGlobalId(UUID.randomUUID().toString());
+        logEntry.setErrorDate(new Date());
+        logEntry.setExceptionMessage("test-exception-mesage");
+        logEntry.setExceptionType(ServiceException.class.getCanonicalName());
+        logEntry.setExceptionStacktrace("test-stack-trace");
+        logEntry.setHeaders("{\"a\", {\"b\"}}");
+
+        errorLoggerDao.logError(logEntry).subscribe(() -> {}, (e) -> fail("DB called return error"));
+    }
+}

--- a/src/test/java/com/atypon/wayf/facade/impl/ErrorLoggerFacadeMockImpl.java
+++ b/src/test/java/com/atypon/wayf/facade/impl/ErrorLoggerFacadeMockImpl.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 Atypon Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atypon.wayf.facade.impl;
+
+import com.atypon.wayf.facade.ErrorLoggerFacade;
+import io.reactivex.Completable;
+
+public class ErrorLoggerFacadeMockImpl implements ErrorLoggerFacade {
+    private int statusCode;
+    private Throwable exception;
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public Throwable getException() {
+        return exception;
+    }
+
+    @Override
+    public Completable buildAndLogError(int statusCode, Throwable t) {
+        this.statusCode = statusCode;
+        this.exception = t;
+
+        return Completable.complete();
+    }
+}

--- a/src/test/java/com/atypon/wayf/facade/impl/ErrorLoggerFacadeTest.java
+++ b/src/test/java/com/atypon/wayf/facade/impl/ErrorLoggerFacadeTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2017 Atypon Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atypon.wayf.facade.impl;
+
+import com.atypon.wayf.dao.impl.ErrorLoggerDaoMockImpl;
+import com.atypon.wayf.data.ErrorLogEntry;
+import com.atypon.wayf.data.ServiceException;
+import com.atypon.wayf.data.publisher.Publisher;
+import com.atypon.wayf.facade.ErrorLoggerFacade;
+import com.atypon.wayf.request.RequestContext;
+import com.atypon.wayf.request.RequestContextAccessor;
+import com.google.common.collect.Lists;
+import io.vertx.core.http.HttpMethod;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.InetAddress;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class ErrorLoggerFacadeTest {
+
+    private ErrorLoggerFacade errorLoggerFacade;
+    private ErrorLoggerDaoMockImpl mockDao;
+
+    @Before
+    public void setup() {
+        ErrorLoggerFacadeImpl facadeImpl = new ErrorLoggerFacadeImpl();
+        mockDao = new ErrorLoggerDaoMockImpl();
+        facadeImpl.setErrorLoggerDao(mockDao);
+        errorLoggerFacade = facadeImpl;
+    }
+
+    @Test
+    public void testErrorLogger() throws Exception {
+        String serverIp = InetAddress.getLocalHost().getHostAddress();
+
+        Publisher authenticatable = new Publisher();
+        authenticatable.setId(123L);
+
+        int statusCode = 500;
+        String errorMessage = "Test error message";
+        String url = "localhost:8080/error";
+        String token = "testToken";
+        String forwardedFor = "127.0.0.1";
+        String globalId = "test-global-id";
+        String httpMethod = HttpMethod.POST.toString();
+        String requestBody = "{ \"body\" : \"end\" }";
+        String userAgent = "test-user-agent";
+
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("Authentication", Lists.newArrayList(token));
+        headers.put("X-Forwarded-For", Lists.newArrayList(forwardedFor));
+        headers.put("X-Device-Id", Lists.newArrayList(globalId));
+        headers.put("User-Agent", Lists.newArrayList(userAgent));
+
+        ServiceException exception = new ServiceException(statusCode, errorMessage);
+
+        RequestContext requestContext = new RequestContext()
+                .setRequestUrl(url)
+                .setHeaders(headers)
+                .setDeviceId(globalId)
+                .setApiToken(token)
+                .setAuthenticated(authenticatable)
+                .setHttpMethod(httpMethod)
+                .setUserAgent(userAgent)
+                .setRequestBody(requestBody);
+
+        RequestContextAccessor.set(requestContext);
+
+        errorLoggerFacade.buildAndLogError(statusCode, exception);
+
+        ErrorLogEntry loggedError = mockDao.getLastLoggedError();
+
+        assertEquals(authenticatable.getType() + "-" + authenticatable.getId(), loggedError.getAuthenticatedParty());
+        assertEquals(errorMessage, loggedError.getExceptionMessage());
+        assertEquals(statusCode, loggedError.getResponseCode());
+        assertEquals(url, loggedError.getRequestUrl());
+        assertEquals(headers.toString(), loggedError.getHeaders());
+        assertEquals(forwardedFor, loggedError.getCallerIp());
+        assertEquals(globalId, loggedError.getDeviceGlobalId());
+        assertEquals(httpMethod, loggedError.getHttpMethod());
+        assertEquals(ServiceException.class.getCanonicalName(), loggedError.getExceptionType());
+        assertNotNull(loggedError.getExceptionStacktrace());
+        assertEquals(serverIp, loggedError.getServerIp());
+        assertNotNull(loggedError.getErrorDate());
+    }
+}

--- a/src/test/java/com/atypon/wayf/request/ResponseWriterTest.java
+++ b/src/test/java/com/atypon/wayf/request/ResponseWriterTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 public class ResponseWriterTest {
     private class ResponseWriterMock extends ResponseWriter {
         public String _getLinkHeaderValue() {
-            return super.getLinkHeaderValue();
+            return super.buildLinkHeaderValue();
         }
     }
 

--- a/src/test/java/com/atypon/wayf/request/ResponseWriterTest.java
+++ b/src/test/java/com/atypon/wayf/request/ResponseWriterTest.java
@@ -16,33 +16,295 @@
 
 package com.atypon.wayf.request;
 
+import com.atypon.wayf.data.ServiceException;
+import com.atypon.wayf.facade.ErrorLoggerFacade;
+import com.atypon.wayf.facade.impl.ErrorLoggerFacadeMockImpl;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.auth.User;
+import io.vertx.ext.web.*;
+import org.apache.http.HttpStatus;
 import org.junit.After;
-import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
 public class ResponseWriterTest {
-    private class ResponseWriterMock extends ResponseWriter {
-        public String _getLinkHeaderValue() {
-            return super.buildLinkHeaderValue();
-        }
+
+    private ResponseWriterMock responseWriter;
+    private ErrorLoggerFacadeMockImpl errorLoggerFacade;
+
+    @Before
+    public void setup() {
+        ResponseWriterMock responseWriterMock = new ResponseWriterMock();
+        errorLoggerFacade = new ErrorLoggerFacadeMockImpl();
+        responseWriterMock.setErrorLoggerFacade(errorLoggerFacade);
+        this.responseWriter = responseWriterMock;
     }
 
     @After
-    public void setup() {
+    public void teardown() {
         RequestContextAccessor.set(null);
     }
 
     @Test
     public void testHasMore() {
         RequestContextAccessor.set(new RequestContext().setRequestUrl("http://localhost:8080/list?param1=1&limit=30&offset=0").setOffset(0).setLimit(30).setHasAnotherDbPage(Boolean.TRUE));
-        String link = new ResponseWriterMock()._getLinkHeaderValue();
-        Assert.assertEquals("<http://localhost:8080/list?param1=1&limit=30&offset=30>; rel=\"next\"", link);
+        String link = responseWriter._getLinkHeaderValue();
+        assertEquals("<http://localhost:8080/list?param1=1&limit=30&offset=30>; rel=\"next\"", link);
     }
 
     @Test
     public void testHasNoMore() {
         RequestContextAccessor.set(new RequestContext().setRequestUrl("/list").setOffset(0).setLimit(30).setHasAnotherDbPage(Boolean.FALSE));
-        String link = new ResponseWriterMock()._getLinkHeaderValue();
-        Assert.assertEquals("", link);
+        String link = responseWriter._getLinkHeaderValue();
+        assertEquals("", link);
+    }
+
+    @Test
+    public void testLogsError() {
+        responseWriter.buildFailure(new RoutingContextMock());
+
+        int statusCode = errorLoggerFacade.getStatusCode();
+        Throwable exception = errorLoggerFacade.getException();
+
+        assertEquals(HttpStatus.SC_FAILED_DEPENDENCY, statusCode);
+        assertEquals(ServiceException.class, exception.getClass());
+    }
+
+    private class ResponseWriterMock extends ResponseWriter {
+        public ResponseWriterMock() {
+        }
+
+        public void setErrorLoggerFacade(ErrorLoggerFacade errorLoggerFacade) {
+            super.errorLoggerFacade = errorLoggerFacade;
+        }
+
+        public String _getLinkHeaderValue() {
+            return super.buildLinkHeaderValue();
+        }
+    }
+
+    private class RoutingContextMock implements RoutingContext {
+        @Override
+        public HttpServerRequest request() {
+            return null;
+        }
+
+        @Override
+        public HttpServerResponse response() {
+            return null;
+        }
+
+        @Override
+        public void next() {
+
+        }
+
+        @Override
+        public void fail(int statusCode) {
+
+        }
+
+        @Override
+        public void fail(Throwable throwable) {
+
+        }
+
+        @Override
+        public RoutingContext put(String key, Object obj) {
+            return null;
+        }
+
+        @Override
+        public <T> T get(String key) {
+            return null;
+        }
+
+        @Override
+        public Map<String, Object> data() {
+            return null;
+        }
+
+        @Override
+        public Vertx vertx() {
+            return null;
+        }
+
+        @Override
+        public String mountPoint() {
+            return null;
+        }
+
+        @Override
+        public Route currentRoute() {
+            return null;
+        }
+
+        @Override
+        public String normalisedPath() {
+            return null;
+        }
+
+        @Override
+        public Cookie getCookie(String name) {
+            return null;
+        }
+
+        @Override
+        public RoutingContext addCookie(Cookie cookie) {
+            return null;
+        }
+
+        @Override
+        public Cookie removeCookie(String name) {
+            return null;
+        }
+
+        @Override
+        public int cookieCount() {
+            return 0;
+        }
+
+        @Override
+        public Set<Cookie> cookies() {
+            return null;
+        }
+
+        @Override
+        public String getBodyAsString() {
+            return null;
+        }
+
+        @Override
+        public String getBodyAsString(String encoding) {
+            return null;
+        }
+
+        @Override
+        public JsonObject getBodyAsJson() {
+            return null;
+        }
+
+        @Override
+        public JsonArray getBodyAsJsonArray() {
+            return null;
+        }
+
+        @Override
+        public Buffer getBody() {
+            return null;
+        }
+
+        @Override
+        public Set<FileUpload> fileUploads() {
+            return null;
+        }
+
+        @Override
+        public Session session() {
+            return null;
+        }
+
+        @Override
+        public User user() {
+            return null;
+        }
+
+        @Override
+        public Throwable failure() {
+            return new ServiceException(HttpStatus.SC_FAILED_DEPENDENCY, "test");
+        }
+
+        @Override
+        public int statusCode() {
+            return 0;
+        }
+
+        @Override
+        public String getAcceptableContentType() {
+            return null;
+        }
+
+        @Override
+        public int addHeadersEndHandler(Handler<Void> handler) {
+            return 0;
+        }
+
+        @Override
+        public boolean removeHeadersEndHandler(int handlerID) {
+            return false;
+        }
+
+        @Override
+        public int addBodyEndHandler(Handler<Void> handler) {
+            return 0;
+        }
+
+        @Override
+        public boolean removeBodyEndHandler(int handlerID) {
+            return false;
+        }
+
+        @Override
+        public boolean failed() {
+            return false;
+        }
+
+        @Override
+        public void setBody(Buffer body) {
+
+        }
+
+        @Override
+        public void setSession(Session session) {
+
+        }
+
+        @Override
+        public void setUser(User user) {
+
+        }
+
+        @Override
+        public void clearUser() {
+
+        }
+
+        @Override
+        public void setAcceptableContentType(String contentType) {
+
+        }
+
+        @Override
+        public void reroute(HttpMethod method, String path) {
+
+        }
+
+        @Override
+        public List<Locale> acceptableLocales() {
+            return null;
+        }
+
+        @Override
+        public void reroute(String path) {
+
+        }
+
+        @Override
+        public Locale preferredLocale() {
+            return null;
+        }
     }
 }

--- a/src/test/resources/create_wayf_tables.sql
+++ b/src/test/resources/create_wayf_tables.sql
@@ -176,3 +176,25 @@ CREATE TABLE `device_access` (
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
 -- Dump completed on 2017-05-04 14:13:29
+
+DROP TABLE IF EXISTS `error_log`;
+
+CREATE TABLE `error_log` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `authenticated_party` VARCHAR(45) NULL,
+  `device_global_id` VARCHAR(36) NULL,
+  `http_method` VARCHAR(6) NULL,
+  `request_url` VARCHAR(200) NULL,
+  `headers` VARCHAR(450) NULL,
+  `caller_ip` VARCHAR(45) NULL,
+  `server_ip` VARCHAR(20) NULL,
+  `response_code` VARCHAR(45) NULL,
+  `exception_type` VARCHAR(100) NULL,
+  `exception_message` VARCHAR(250) NULL,
+  `exception_stacktrace` LONGTEXT NULL,
+  `error_date` DATETIME NULL,
+  `created_date` DATETIME NULL DEFAULT CURRENT_TIMESTAMP,
+  `modified_date` DATETIME DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+UNIQUE KEY `id_UNIQUE` (`id`)
+);

--- a/src/test/resources/create_wayf_tables.sql
+++ b/src/test/resources/create_wayf_tables.sql
@@ -191,7 +191,7 @@ CREATE TABLE `error_log` (
   `response_code` VARCHAR(45) NULL,
   `exception_type` VARCHAR(100) NULL,
   `exception_message` VARCHAR(250) NULL,
-  `exception_stacktrace` LONGTEXT NULL,
+  `exception_stacktrace` TEXT NULL,
   `error_date` DATETIME NULL,
   `created_date` DATETIME NULL DEFAULT CURRENT_TIMESTAMP,
   `modified_date` DATETIME DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,


### PR DESCRIPTION
Added an error logger that will log all failures on HTTP request to a database table. While this information is available throughout the logs, this will correlate information like the request URL, authenticated party, HTTP headers, etc to the exception. This will be useful for debugging errors and production support.