### PR TITLE
Support for "registering" a local ID with server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,11 @@
       <artifactId>json-path-assert</artifactId>
       <version>2.2.0</version>
     </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt</artifactId>
+      <version>0.7.0</version>
+    </dependency>
   </dependencies>
 
 

--- a/src/main/java/com/atypon/wayf/dao/DeviceDao.java
+++ b/src/main/java/com/atypon/wayf/dao/DeviceDao.java
@@ -30,7 +30,7 @@ public interface DeviceDao {
     Completable delete(String id);
     Observable<Device> filter(DeviceQuery query);
 
-    Completable updateDevicePublisherLocalIdXref(Long deviceId, Long publisherId, String localId);
+    Single<Integer> updateDevicePublisherLocalIdXref(Long deviceId, Long publisherId, String localId);
 
     Completable registerLocalId(Long publisherId, String localId);
 

--- a/src/main/java/com/atypon/wayf/dao/DeviceDao.java
+++ b/src/main/java/com/atypon/wayf/dao/DeviceDao.java
@@ -30,7 +30,9 @@ public interface DeviceDao {
     Completable delete(String id);
     Observable<Device> filter(DeviceQuery query);
 
-    Completable replaceDevicePublisherLocalIdXref(Long deviceId, Long publisherId, String localId);
+    Completable updateDevicePublisherLocalIdXref(Long deviceId, Long publisherId, String localId);
+
+    Completable registerLocalId(Long publisherId, String localId);
 
     Maybe<Device> readByPublisherLocalId(Long publisherId, String localId);
 }

--- a/src/main/java/com/atypon/wayf/dao/impl/DeviceDaoDbImpl.java
+++ b/src/main/java/com/atypon/wayf/dao/impl/DeviceDaoDbImpl.java
@@ -120,15 +120,15 @@ public class DeviceDaoDbImpl implements DeviceDao {
     }
 
     @Override
-    public Completable updateDevicePublisherLocalIdXref(Long deviceId, Long publisherId, String localId) {
+    public Single<Integer> updateDevicePublisherLocalIdXref(Long deviceId, Long publisherId, String localId) {
         Map<String, Object> args = new HashMap<>();
         args.put(DEVICE_ID, deviceId);
         args.put(PUBLISHER_ID, publisherId);
         args.put(PUBLISHER_LOCAL_ID, localId);
         args.put(UNIQUE_PUBLISHER_KEY, publisherId + "-" + localId);
 
-        return Completable.fromSingle(dbExecutor.executeUpdate(replacePublisherLocalIdXrefSql, args))
-                .compose((completable) -> DaoPolicies.applyCompletable(completable));
+        return dbExecutor.executeUpdateRowCount(replacePublisherLocalIdXrefSql, args)
+                .compose((single) -> DaoPolicies.applySingle(single));
     }
 
     @Override

--- a/src/main/java/com/atypon/wayf/data/AuthorizationToken.java
+++ b/src/main/java/com/atypon/wayf/data/AuthorizationToken.java
@@ -14,17 +14,31 @@
  * limitations under the License.
  */
 
-package com.atypon.wayf.facade;
+package com.atypon.wayf.data;
 
-import com.atypon.wayf.data.publisher.Publisher;
-import com.atypon.wayf.data.publisher.PublisherQuery;
-import io.reactivex.Observable;
-import io.reactivex.Single;
+public class AuthorizationToken {
 
-public interface PublisherFacade {
-    Single<Publisher> create(Publisher publisher);
-    Single<Publisher> read(Long id);
-    Observable<Publisher> filter(PublisherQuery filter);
+    private AuthorizationTokenType type;
+    private String value;
 
-    Single<Publisher> lookupCode(String publisherCode);
+    public AuthorizationToken() {
+    }
+
+    public AuthorizationTokenType getType() {
+        return type;
+    }
+
+    public AuthorizationToken setType(AuthorizationTokenType type) {
+        this.type = type;
+        return this;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public AuthorizationToken setValue(String value) {
+        this.value = value;
+        return this;
+    }
 }

--- a/src/main/java/com/atypon/wayf/data/AuthorizationTokenType.java
+++ b/src/main/java/com/atypon/wayf/data/AuthorizationTokenType.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 Atypon Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atypon.wayf.data;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum AuthorizationTokenType {
+    API_TOKEN("API"),
+    JWT("Bearer");
+
+    private static final Map<String, AuthorizationTokenType> PREFIX_TO_TYPE_MAP = new HashMap<>();
+
+    static {
+        for (AuthorizationTokenType type : AuthorizationTokenType.values()) {
+            PREFIX_TO_TYPE_MAP.put(type.getPrefix(), type);
+        }
+    }
+
+    private String prefix;
+
+    AuthorizationTokenType(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public static AuthorizationTokenType fromPrefix(String prefix) {
+        return PREFIX_TO_TYPE_MAP.get(prefix);
+    }
+}

--- a/src/main/java/com/atypon/wayf/data/publisher/PublisherQuery.java
+++ b/src/main/java/com/atypon/wayf/data/publisher/PublisherQuery.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 
 public class PublisherQuery {
     private Collection<Long> ids;
+    private Collection<String> codes;
 
     public PublisherQuery() {
     }
@@ -39,5 +40,18 @@ public class PublisherQuery {
      */
     public boolean isNullIds() {
         return ids == null;
+    }
+
+    public Collection<String> getCodes() {
+        return codes;
+    }
+
+    public PublisherQuery setCodes(Collection<String> codes) {
+        this.codes = codes;
+        return this;
+    }
+
+    public boolean isNullCodes() {
+        return codes == null;
     }
 }

--- a/src/main/java/com/atypon/wayf/database/DbExecutor.java
+++ b/src/main/java/com/atypon/wayf/database/DbExecutor.java
@@ -90,6 +90,16 @@ public class DbExecutor {
         return Single.just(query)
                 .map((ignored) -> namedParameterJdbcTemplate.update(query, new MapSqlParameterSource(arguments), keyHolder))
                 .map((ignored) -> keyHolder.getKey() == null? null : keyHolder.getKey().longValue());
+    }
 
+    public Single<Integer> executeUpdateRowCount(String query, Object arguments) {
+        return executeUpdateRowCount(query, QueryMapper.buildQueryArguments(query, arguments));
+    }
+
+    public Single<Integer> executeUpdateRowCount(String query, Map<String, Object> arguments) {
+        LOG.debug("Running update [{}] with values [{}]", query, arguments);
+
+        return Single.just(query)
+                .map((ignored) -> namedParameterJdbcTemplate.update(query, new MapSqlParameterSource(arguments)));
     }
 }

--- a/src/main/java/com/atypon/wayf/database/DbExecutor.java
+++ b/src/main/java/com/atypon/wayf/database/DbExecutor.java
@@ -88,7 +88,7 @@ public class DbExecutor {
 
         GeneratedKeyHolder keyHolder = new GeneratedKeyHolder();
         return Single.just(query)
-                .map((ignored) ->  namedParameterJdbcTemplate.update(query, new MapSqlParameterSource(arguments), keyHolder))
+                .map((ignored) -> namedParameterJdbcTemplate.update(query, new MapSqlParameterSource(arguments), keyHolder))
                 .map((ignored) -> keyHolder.getKey() == null? null : keyHolder.getKey().longValue());
 
     }

--- a/src/main/java/com/atypon/wayf/facade/AuthenticationFacade.java
+++ b/src/main/java/com/atypon/wayf/facade/AuthenticationFacade.java
@@ -17,9 +17,11 @@
 package com.atypon.wayf.facade;
 
 import com.atypon.wayf.data.Authenticatable;
+import com.atypon.wayf.data.AuthorizationToken;
 import io.reactivex.Single;
 
 public interface AuthenticationFacade {
     Single<String> createToken(Authenticatable authenticatable);
-    Authenticatable authenticate(String token);
+    Authenticatable authenticate(AuthorizationToken token);
+    AuthorizationToken parseAuthenticationValue(String authenticationValue);
 }

--- a/src/main/java/com/atypon/wayf/facade/DeviceFacade.java
+++ b/src/main/java/com/atypon/wayf/facade/DeviceFacade.java
@@ -26,7 +26,7 @@ public interface DeviceFacade {
     Single<Device> create(Device device);
     Single<Device> read(DeviceQuery query);
 
-    Single<Device> createOrUpdateForPublisher(String publisherCode, String localId);
+    Single<Device> relateLocalIdToDevice(String publisherCode, String localId);
 
     Observable<Device> filter(DeviceQuery query);
 

--- a/src/main/java/com/atypon/wayf/facade/DeviceFacade.java
+++ b/src/main/java/com/atypon/wayf/facade/DeviceFacade.java
@@ -18,6 +18,7 @@ package com.atypon.wayf.facade;
 
 import com.atypon.wayf.data.device.Device;
 import com.atypon.wayf.data.device.DeviceQuery;
+import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 
@@ -25,9 +26,11 @@ public interface DeviceFacade {
     Single<Device> create(Device device);
     Single<Device> read(DeviceQuery query);
 
-    Single<Device> createOrUpdateForPublisher(String localId);
+    Single<Device> createOrUpdateForPublisher(String publisherCode, String localId);
 
     Observable<Device> filter(DeviceQuery query);
+
+    Completable registerLocalId(String localId);
 
     Single<Device> readByLocalId(String localId);
 }

--- a/src/main/java/com/atypon/wayf/facade/impl/AuthenticatableFacadeImpl.java
+++ b/src/main/java/com/atypon/wayf/facade/impl/AuthenticatableFacadeImpl.java
@@ -18,6 +18,8 @@ package com.atypon.wayf.facade.impl;
 
 import com.atypon.wayf.dao.AuthenticationDao;
 import com.atypon.wayf.data.Authenticatable;
+import com.atypon.wayf.data.AuthorizationToken;
+import com.atypon.wayf.data.AuthorizationTokenType;
 import com.atypon.wayf.data.ServiceException;
 import com.atypon.wayf.facade.AuthenticationFacade;
 import com.google.common.cache.CacheBuilder;
@@ -30,11 +32,24 @@ import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class AuthenticatableFacadeImpl implements AuthenticationFacade {
     private static final Logger LOG = LoggerFactory.getLogger(AuthenticatableFacadeImpl.class);
+
+    private static final String TOKEN_REGEX = "(API|Bearer) (.*)";
+    private static final Pattern TOKEN_MATCHER = Pattern.compile(TOKEN_REGEX, Pattern.DOTALL);
+
+    private static final Map<String, AuthorizationTokenType> TOKEN_PREFIX_TO_TYPE_MAP = new HashMap<>();
+
+    static {
+
+    }
 
     protected LoadingCache<String, Authenticatable> l1Cache = CacheBuilder.newBuilder()
             .maximumSize(100)
@@ -66,13 +81,35 @@ public class AuthenticatableFacadeImpl implements AuthenticationFacade {
     }
 
     @Override
-    public Authenticatable authenticate(String token) {
+    public Authenticatable authenticate(AuthorizationToken token) {
         LOG.debug("Authenticating token");
 
+        if (AuthorizationTokenType.API_TOKEN != token.getType()) {
+            return null;
+        }
+
         try {
-            return l1Cache.get(token);
+            return l1Cache.get(token.getValue());
         } catch (Exception e) {
             throw new ServiceException(HttpStatus.SC_UNAUTHORIZED, "Could not authenticate token", e);
         }
+    }
+
+    @Override
+    public AuthorizationToken parseAuthenticationValue(String authenticationValue) {
+        Matcher matcher = TOKEN_MATCHER.matcher(authenticationValue);
+
+        if (matcher.find()) {
+            String prefix = matcher.group(1);
+            String value = matcher.group(2);
+
+            AuthorizationToken token = new AuthorizationToken();
+            token.setType(AuthorizationTokenType.fromPrefix(prefix));
+            token.setValue(value);
+
+            return token;
+        }
+
+        throw new ServiceException(HttpStatus.SC_BAD_REQUEST, "Could not parse Authentication header");
     }
 }

--- a/src/main/java/com/atypon/wayf/facade/impl/PublisherFacadeImpl.java
+++ b/src/main/java/com/atypon/wayf/facade/impl/PublisherFacadeImpl.java
@@ -21,6 +21,7 @@ import com.atypon.wayf.data.publisher.Publisher;
 import com.atypon.wayf.data.publisher.PublisherQuery;
 import com.atypon.wayf.data.publisher.PublisherStatus;
 import com.atypon.wayf.facade.PublisherFacade;
+import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import io.reactivex.Observable;
@@ -53,5 +54,12 @@ public class PublisherFacadeImpl implements PublisherFacade {
     @Override
     public Observable<Publisher> filter(PublisherQuery filter) {
         return publisherDao.filter(filter);
+    }
+
+    @Override
+    public Single<Publisher> lookupCode(String publisherCode) {
+        PublisherQuery query = new PublisherQuery().setCodes(Lists.newArrayList(publisherCode));
+
+        return singleOrException(filter(query), HttpStatus.SC_BAD_REQUEST, "Could not find publisher for code [{}]", publisherCode);
     }
 }

--- a/src/main/java/com/atypon/wayf/reactivex/FacadePolicies.java
+++ b/src/main/java/com/atypon/wayf/reactivex/FacadePolicies.java
@@ -84,14 +84,15 @@ public class FacadePolicies {
     }
 
     public static final <T> Single<T> singleOrException(Observable<T> observable, int statusCode, String message, Object... args) {
-        Single<Boolean> isEmpty = observable.isEmpty();
+        Single<Long> count = observable.count();
 
-        return isEmpty.flatMap((_isEmpty) -> {
-            if (_isEmpty) {
+        return count.flatMap((_count) -> {
+            if (_count != 1) {
                 FormattingTuple formattedMessage = MessageFormatter.arrayFormat(message, args);
 
                 throw new ServiceException(statusCode, formattedMessage.getMessage());
             }
+
 
             return observable.singleOrError();
         });

--- a/src/main/java/com/atypon/wayf/request/RequestContext.java
+++ b/src/main/java/com/atypon/wayf/request/RequestContext.java
@@ -17,6 +17,7 @@
 package com.atypon.wayf.request;
 
 import com.atypon.wayf.data.Authenticatable;
+import com.atypon.wayf.data.AuthorizationToken;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,7 +33,7 @@ public class RequestContext {
     private Integer limit = DEFAULT_LIMIT;
     private Integer offset = DEFAULT_OFFSET;
 
-    private String apiToken;
+    private AuthorizationToken authorizationToken;
     private String httpMethod;
     private String requestBody;
     private String userAgent;
@@ -48,12 +49,12 @@ public class RequestContext {
     public RequestContext() {
     }
 
-    public String getApiToken() {
-        return apiToken;
+    public AuthorizationToken getAuthorizationToken() {
+        return authorizationToken;
     }
 
-    public RequestContext setApiToken(String apiToken) {
-        this.apiToken = apiToken;
+    public RequestContext setAuthorizationToken(AuthorizationToken authorizationToken) {
+        this.authorizationToken = authorizationToken;
         return this;
     }
 

--- a/src/main/java/com/atypon/wayf/verticle/WayfRequestHandlerFactory.java
+++ b/src/main/java/com/atypon/wayf/verticle/WayfRequestHandlerFactory.java
@@ -17,6 +17,7 @@
 package com.atypon.wayf.verticle;
 
 import com.atypon.wayf.data.Authenticatable;
+import com.atypon.wayf.data.AuthorizationToken;
 import com.atypon.wayf.facade.AuthenticationFacade;
 import com.atypon.wayf.request.RequestContext;
 import com.atypon.wayf.request.RequestContextAccessor;
@@ -151,9 +152,9 @@ public class WayfRequestHandlerFactory {
     }
 
     private final void authenticate() {
-        String apiToken = RequestContextAccessor.get().getApiToken();
-        if (apiToken != null && !apiToken.isEmpty()) {
-            Authenticatable authenticated = authenticationFacade.authenticate(apiToken);
+        AuthorizationToken token = RequestContextAccessor.get().getAuthorizationToken();
+        if (token != null) {
+            Authenticatable authenticated = authenticationFacade.authenticate(token);
             RequestContextAccessor.get().setAuthenticated(authenticated);
         }
     }

--- a/src/main/java/com/atypon/wayf/verticle/routing/DeviceRoutingProvider.java
+++ b/src/main/java/com/atypon/wayf/verticle/routing/DeviceRoutingProvider.java
@@ -119,7 +119,7 @@ public class DeviceRoutingProvider implements RoutingProvider {
 
         String publisherCode = claims.get(PUBLISHER_CODE_KEY, String.class);
 
-        return deviceFacade.createOrUpdateForPublisher(publisherCode, localId)
+        return deviceFacade.relateLocalIdToDevice(publisherCode, localId)
                 .map((device) -> {
                     String globalId = device.getGlobalId();
                     responseWriter.setDeviceIdHeader(routingContext, globalId);

--- a/src/main/java/com/atypon/wayf/verticle/routing/DeviceRoutingProvider.java
+++ b/src/main/java/com/atypon/wayf/verticle/routing/DeviceRoutingProvider.java
@@ -16,23 +16,32 @@
 
 package com.atypon.wayf.verticle.routing;
 
+import com.atypon.wayf.data.AuthorizationToken;
 import com.atypon.wayf.data.InflationPolicyParser;
+import com.atypon.wayf.data.ServiceException;
 import com.atypon.wayf.data.device.Device;
 import com.atypon.wayf.data.device.DeviceQuery;
 import com.atypon.wayf.facade.DeviceFacade;
+import com.atypon.wayf.request.RequestContextAccessor;
 import com.atypon.wayf.request.RequestReader;
 import com.atypon.wayf.request.ResponseWriter;
 import com.atypon.wayf.verticle.WayfRequestHandlerFactory;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.reactivex.Completable;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
+import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.xml.bind.DatatypeConverter;
 
 @Singleton
 public class DeviceRoutingProvider implements RoutingProvider {
@@ -44,6 +53,9 @@ public class DeviceRoutingProvider implements RoutingProvider {
     private static final String READ_DEVICE = "/1/device/:id";
     private static final String FILTER_DEVICE = "/1/devices";
     private static final String ADD_DEVICE_PUBLISHER_RELATIONSHIP = "/1/device/:localId";
+
+    private static final String PUBLISHER_CODE_KEY = "publisherCode";
+    private static final String SECRET_JWT_KEY = "shh_its_a_secret";
 
     @Inject
     private ResponseWriter responseWriter;
@@ -64,6 +76,7 @@ public class DeviceRoutingProvider implements RoutingProvider {
         router.route("/1/device*").handler(BodyHandler.create());
         router.get(READ_DEVICE).handler(handlerFactory.single((rc) -> readDevice(rc)));
         router.get(FILTER_DEVICE).handler(handlerFactory.observable((rc) -> filterDevice(rc)));
+        router.post(ADD_DEVICE_PUBLISHER_RELATIONSHIP).handler(handlerFactory.completable((rc) -> registerLocalId(rc)));
         router.patch(ADD_DEVICE_PUBLISHER_RELATIONSHIP).handler(handlerFactory.single((rc) -> createPublisherDeviceRelationship(rc)));
     }
 
@@ -83,12 +96,30 @@ public class DeviceRoutingProvider implements RoutingProvider {
         return deviceFacade.filter(query);
     }
 
+    public Completable registerLocalId(RoutingContext routingContext) {
+        String localId = RequestReader.readPathArgument(routingContext, LOCAL_ID_PARAM);
+
+        return deviceFacade.registerLocalId(localId);
+    }
+
     public Single<Device> createPublisherDeviceRelationship(RoutingContext routingContext) {
         LOG.debug("Received request to create publisher/device relationship");
 
         String localId = RequestReader.readPathArgument(routingContext, LOCAL_ID_PARAM);
 
-        return deviceFacade.createOrUpdateForPublisher(localId)
+        AuthorizationToken token = RequestContextAccessor.get().getAuthorizationToken();
+        if (token == null) {
+            throw new ServiceException(HttpStatus.SC_BAD_REQUEST, "An Authorization token is required");
+        }
+
+        Claims claims = Jwts.parser()
+                .setSigningKey(DatatypeConverter.parseBase64Binary(SECRET_JWT_KEY))
+                .parseClaimsJws(token.getValue())
+                .getBody();
+
+        String publisherCode = claims.get(PUBLISHER_CODE_KEY, String.class);
+
+        return deviceFacade.createOrUpdateForPublisher(publisherCode, localId)
                 .map((device) -> {
                     String globalId = device.getGlobalId();
                     responseWriter.setDeviceIdHeader(routingContext, globalId);

--- a/src/main/resources/dao/device-dao-db.properties
+++ b/src/main/resources/dao/device-dao-db.properties
@@ -56,6 +56,13 @@ SELECT d.id, \
         WHERE xref.publisher_id = :publisher.id AND xref.local_id = :localId \
 ORDER BY d.created_date ASC LIMIT :limit OFFSET :offset;
 
-device.dao.db.create-publisher-local-id-xref= \
-REPLACE INTO wayf.publisher_local_id_device_xref (device_id, publisher_id, local_id, unique_publisher_key) \
-    VALUES (:device.id, :publisher.id, :localId, :uniquePublisherKey);
+device.dao.db.update-publisher-local-id-xref= \
+UPDATE wayf.publisher_local_id_device_xref \
+  SET device_id = :device.id \
+        WHERE local_id = :localId \
+                AND publisher_id = :publisher.id;
+
+device.dao.db.register-local-id-xref= \
+INSERT INTO wayf.publisher_local_id_device_xref (publisher_id, local_id, unique_publisher_key) \
+    VALUES (:publisher.id, :localId, :uniquePublisherKey) \
+ON DUPLICATE KEY UPDATE modified_date = CURRENT_TIMESTAMP;

--- a/src/main/resources/dao/publisher-dao-db.properties
+++ b/src/main/resources/dao/publisher-dao-db.properties
@@ -45,4 +45,5 @@ SELECT id, \
         modified_date AS modifiedDate \
     FROM wayf.publisher \
         WHERE (:nullIds OR id IN (:ids)) \
+                AND (:nullCodes OR code IN (:codes)) \
 ORDER BY id ASC LIMIT :limit OFFSET :offset;

--- a/src/test/java/com/atypon/wayf/dao/impl/DeviceDaoDbImplTest.java
+++ b/src/test/java/com/atypon/wayf/dao/impl/DeviceDaoDbImplTest.java
@@ -90,7 +90,8 @@ public class DeviceDaoDbImplTest {
         Long publisherId = 123L;
         String localId = UUID.randomUUID().toString();
 
-        dao.replaceDevicePublisherLocalIdXref(createdDevice.getId(), publisherId, localId).blockingGet();
+        dao.registerLocalId(publisherId, localId).blockingGet();
+        dao.updateDevicePublisherLocalIdXref(createdDevice.getId(), publisherId, localId).blockingGet();
 
         Device readByLocalId = dao.readByPublisherLocalId(publisherId, localId).blockingGet();
         assertEquals(createdDevice.getId(), readByLocalId.getId());

--- a/src/test/java/com/atypon/wayf/facade/impl/ErrorLoggerFacadeTest.java
+++ b/src/test/java/com/atypon/wayf/facade/impl/ErrorLoggerFacadeTest.java
@@ -17,6 +17,8 @@
 package com.atypon.wayf.facade.impl;
 
 import com.atypon.wayf.dao.impl.ErrorLoggerDaoMockImpl;
+import com.atypon.wayf.data.AuthorizationToken;
+import com.atypon.wayf.data.AuthorizationTokenType;
 import com.atypon.wayf.data.ErrorLogEntry;
 import com.atypon.wayf.data.ServiceException;
 import com.atypon.wayf.data.publisher.Publisher;
@@ -78,7 +80,7 @@ public class ErrorLoggerFacadeTest {
                 .setRequestUrl(url)
                 .setHeaders(headers)
                 .setDeviceId(globalId)
-                .setApiToken(token)
+                .setAuthorizationToken(new AuthorizationToken().setType(AuthorizationTokenType.API_TOKEN).setValue(token))
                 .setAuthenticated(authenticatable)
                 .setHttpMethod(httpMethod)
                 .setUserAgent(userAgent)

--- a/src/test/java/com/atypon/wayf/facade/impl/FacadePoliciesTest.java
+++ b/src/test/java/com/atypon/wayf/facade/impl/FacadePoliciesTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2017 Atypon Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atypon.wayf.facade.impl;
+
+import com.atypon.wayf.data.ServiceException;
+import io.reactivex.Maybe;
+import io.reactivex.Observable;
+import org.apache.http.HttpStatus;
+import org.junit.Test;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static com.atypon.wayf.reactivex.FacadePolicies.singleOrException;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class FacadePoliciesTest {
+
+    @Test
+    public void testMaybeToSingleEmpty() {
+        final List<Object> results = new LinkedList<>();
+
+        singleOrException(Maybe.empty(), HttpStatus.SC_BAD_REQUEST, "Too few elements")
+                .subscribe((ignore) -> fail(), (e) -> results.add(e));
+
+        assertEquals(1, results.size());
+
+        Object result = results.get(0);
+
+        if (result.getClass() != ServiceException.class) {
+            fail();
+        }
+
+        ServiceException serviceException = (ServiceException) result;
+
+        assertEquals(HttpStatus.SC_BAD_REQUEST, serviceException.getStatusCode());
+        assertEquals("Too few elements", serviceException.getMessage());
+    }
+
+    @Test
+    public void testMaybeToSingleOneElement() {
+        final List<Object> results = new LinkedList<>();
+
+        singleOrException(Maybe.just("ABC"), HttpStatus.SC_BAD_REQUEST, "Too few elements")
+                .subscribe((result) -> results.add(result), (e) -> fail(e.getMessage()));
+
+        assertEquals(1, results.size());
+
+        Object result = results.get(0);
+
+        assertEquals("ABC", result);
+    }
+
+    @Test
+    public void testObservableToSingleEmpty() {
+        final List<Object> results = new LinkedList<>();
+
+        singleOrException(Observable.empty(), HttpStatus.SC_BAD_REQUEST, "Too few elements")
+                .subscribe((ignore) -> fail(), (e) -> results.add(e));
+
+        assertEquals(1, results.size());
+
+        Object result = results.get(0);
+
+        if (result.getClass() != ServiceException.class) {
+            fail();
+        }
+
+        ServiceException serviceException = (ServiceException) result;
+
+        assertEquals(HttpStatus.SC_BAD_REQUEST, serviceException.getStatusCode());
+        assertEquals("Too few elements", serviceException.getMessage());
+    }
+
+    @Test
+    public void testObservableToSingleTooMany() {
+        final List<Object> results = new LinkedList<>();
+
+        singleOrException(Observable.just("a", "b", "c"), HttpStatus.SC_BAD_REQUEST, "Too many elements")
+                .subscribe((ignore) -> fail(), (e) -> results.add(e));
+
+        assertEquals(1, results.size());
+
+        Object result = results.get(0);
+
+        if (result.getClass() != ServiceException.class) {
+            fail();
+        }
+
+        ServiceException serviceException = (ServiceException) result;
+
+        assertEquals(HttpStatus.SC_BAD_REQUEST, serviceException.getStatusCode());
+        assertEquals("Too many elements", serviceException.getMessage());
+    }
+
+    @Test
+    public void testObservableToSingleOneElement() {
+        final List<Object> results = new LinkedList<>();
+
+        singleOrException(Observable.just("ABC"), HttpStatus.SC_BAD_REQUEST, "Too few elements")
+                .subscribe((result) -> results.add(result), (e) -> fail(e.getMessage()));
+
+        assertEquals(1, results.size());
+
+        Object result = results.get(0);
+
+        assertEquals("ABC", result);
+    }
+}

--- a/src/test/java/com/atypon/wayf/integration/AuthorizationTokenTestUtil.java
+++ b/src/test/java/com/atypon/wayf/integration/AuthorizationTokenTestUtil.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 Atypon Systems, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.atypon.wayf.integration;
+
+import com.atypon.wayf.data.AuthorizationTokenType;
+import io.jsonwebtoken.JwtBuilder;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+
+import javax.crypto.spec.SecretKeySpec;
+import javax.xml.bind.DatatypeConverter;
+import java.security.Key;
+import java.util.Date;
+
+public class AuthorizationTokenTestUtil {
+    private static final String SECRET_JWT_KEY = "shh_its_a_secret";
+
+    public static String generateApiTokenHeaderValue(String apiKey) {
+        return AuthorizationTokenType.API_TOKEN.getPrefix() + " " + apiKey;
+    }
+
+    public static String generateJwtTokenHeaderValue(String publisherCode) {
+
+        //The JWT signature algorithm we will be using to sign the token
+        SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+        long nowMillis = System.currentTimeMillis();
+        Date now = new Date(nowMillis);
+
+        //We will sign our JWT with our ApiKey secret
+        byte[] apiKeySecretBytes = DatatypeConverter.parseBase64Binary(SECRET_JWT_KEY);
+        Key signingKey = new SecretKeySpec(apiKeySecretBytes, signatureAlgorithm.getJcaName());
+
+        //Let's set the JWT Claims
+        JwtBuilder builder = Jwts.builder().claim("publisherCode", publisherCode)
+                .signWith(signatureAlgorithm, signingKey);
+
+        return AuthorizationTokenType.JWT.getPrefix() + " " + builder.compact();
+    }
+}

--- a/src/test/java/com/atypon/wayf/integration/DeviceAccessTestUtil.java
+++ b/src/test/java/com/atypon/wayf/integration/DeviceAccessTestUtil.java
@@ -38,7 +38,7 @@ public class DeviceAccessTestUtil {
 
     public void testDeviceHistoryError(int statusCode, String localId, String publisherToken, String expectedHistoryJson) {
         Map<String, String> headers = new HashMap<>();
-        headers.put("Authorization", publisherToken);
+        headers.put("Authorization", AuthorizationTokenTestUtil.generateApiTokenHeaderValue(publisherToken));
 
         String historyResponse =
                 request
@@ -60,7 +60,7 @@ public class DeviceAccessTestUtil {
 
     public String testDeviceHistory(String localId, String publisherToken, String expectedHistoryJson) {
         Map<String, String> headers = new HashMap<>();
-        headers.put("Authorization", publisherToken);
+        headers.put("Authorization", AuthorizationTokenTestUtil.generateApiTokenHeaderValue(publisherToken));
 
         String historyResponse =
                 request

--- a/src/test/java/com/atypon/wayf/integration/DeviceTestUtil.java
+++ b/src/test/java/com/atypon/wayf/integration/DeviceTestUtil.java
@@ -33,9 +33,9 @@ public class DeviceTestUtil {
         this.request = request;
     }
 
-    public String relateDeviceToPublisherError(int statusCode, String localId, String publisherToken, String globalId, String expectedResponseJson) {
+    public String relateDeviceToPublisherError(int statusCode, String localId, String publisherCode, String globalId, String expectedResponseJson) {
         Map<String, String> headers = new HashMap<>();
-        headers.put("Authorization", publisherToken);
+        headers.put("Authorization", AuthorizationTokenTestUtil.generateJwtTokenHeaderValue(publisherCode));
         headers.put("User-Agent", "Test-Agent");
         if (globalId != null) {
             headers.put("X-Device-Id", globalId);
@@ -62,9 +62,23 @@ public class DeviceTestUtil {
         return deviceIdHeader;
     }
 
-    public String relateDeviceToPublisher(String localId, String publisherToken, String globalId, String expectedResponseJson) {
+    public void registerLocalId(String localId, String publisherToken) {
         Map<String, String> headers = new HashMap<>();
-        headers.put("Authorization", publisherToken);
+        headers.put("Authorization", AuthorizationTokenTestUtil.generateApiTokenHeaderValue(publisherToken));
+        headers.put("User-Agent", "Test-Agent");
+
+        ExtractableResponse relateResponse = request
+                .headers(headers)
+                .url("/1/device/" + localId)
+                .method(Method.POST)
+                .execute()
+                .statusCode(200)
+                .extract();
+    }
+
+    public String relateDeviceToPublisher(String localId, String publisherCode, String globalId, String expectedResponseJson) {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Authorization", AuthorizationTokenTestUtil.generateJwtTokenHeaderValue(publisherCode));
         headers.put("User-Agent", "Test-Agent");
         if (globalId != null) {
             headers.put("X-Device-Id", globalId);
@@ -95,7 +109,7 @@ public class DeviceTestUtil {
 
     public void deviceQueryBadPublisherToken(String localId, String publisherToken, String expectedResponseJson) {
         Map<String, String> headers = new HashMap<>();
-        headers.put("Authorization", publisherToken);
+        headers.put("Authorization", AuthorizationTokenTestUtil.generateApiTokenHeaderValue(publisherToken));
         headers.put("User-Agent", "Test-Agent");
 
         ExtractableResponse relateBadTokenResponse = request

--- a/src/test/java/com/atypon/wayf/integration/IdentityProviderTestUtil.java
+++ b/src/test/java/com/atypon/wayf/integration/IdentityProviderTestUtil.java
@@ -38,7 +38,7 @@ public class IdentityProviderTestUtil {
 
     public void addIdpToDeviceError(int statusCode, String localId, String publisherToken, String idpBodyJson, String expectedResponseJson) {
         Map<String, String> headers = new HashMap<>();
-        headers.put("Authorization", publisherToken);
+        headers.put("Authorization", AuthorizationTokenTestUtil.generateApiTokenHeaderValue(publisherToken));
 
         String addIdpResponse =
                 request
@@ -60,7 +60,7 @@ public class IdentityProviderTestUtil {
 
     public Long addIdpToDevice(String localId, String publisherToken, String idpBodyJson, String expectedResponseJson) {
         Map<String, String> headers = new HashMap<>();
-        headers.put("Authorization", publisherToken);
+        headers.put("Authorization", AuthorizationTokenTestUtil.generateApiTokenHeaderValue(publisherToken));
 
         String addIdpResponse =
                 request
@@ -101,7 +101,7 @@ public class IdentityProviderTestUtil {
 
     public void removeIdpForDeviceError(int statusCode, String localId, String publisherToken, Long idpId, String expectedResponseJson) {
         Map<String, String> headers = new HashMap<>();
-        headers.put("Authorization", publisherToken);
+        headers.put("Authorization", AuthorizationTokenTestUtil.generateApiTokenHeaderValue(publisherToken));
 
         String removeIdpResponse =
                 request
@@ -122,7 +122,7 @@ public class IdentityProviderTestUtil {
 
     public void removeIdpForDevice(String localId, String publisherToken, Long idpId) {
         Map<String, String> headers = new HashMap<>();
-        headers.put("Authorization", publisherToken);
+        headers.put("Authorization", AuthorizationTokenTestUtil.generateApiTokenHeaderValue(publisherToken));
 
         String removeIdpResponse =
                 request

--- a/src/test/java/com/atypon/wayf/integration/PublisherTestUtil.java
+++ b/src/test/java/com/atypon/wayf/integration/PublisherTestUtil.java
@@ -16,6 +16,7 @@
 
 package com.atypon.wayf.integration;
 
+import com.atypon.wayf.data.publisher.Publisher;
 import com.atypon.wayf.verticle.routing.LoggingHttpRequest;
 import io.restassured.http.ContentType;
 import io.restassured.http.Method;
@@ -30,7 +31,7 @@ public class PublisherTestUtil {
         this.request = request;
     }
 
-    public String testCreatePublisher(String requestBody, String response) {
+    public Publisher testCreatePublisher(String requestBody, String response) {
         String createResponse =
                 request
                         .contentType(ContentType.JSON)
@@ -43,6 +44,7 @@ public class PublisherTestUtil {
 
         String[] createResponseGeneratedFields = {
                 "$.id",
+                "$.code",
                 "$.token",
                 "$.createdDate"
         };
@@ -50,9 +52,14 @@ public class PublisherTestUtil {
         assertNotNullPaths(createResponse, createResponseGeneratedFields);
 
         String token = readField(createResponse, "$.token");
+        String code = readField(createResponse, "$.code");
 
         assertJsonEquals(response, createResponse, createResponseGeneratedFields);
 
-        return token;
+        Publisher publisher = new Publisher();
+        publisher.setCode(code);
+        publisher.setToken(token);
+
+        return publisher;
     }
 }

--- a/src/test/java/com/atypon/wayf/integration/publisher/PublisherIntegrationTest.java
+++ b/src/test/java/com/atypon/wayf/integration/publisher/PublisherIntegrationTest.java
@@ -56,6 +56,7 @@ public class PublisherIntegrationTest extends BaseHttpTest {
     private static final String ERROR_404_BAD_LOCAL_ID_RESPONSE_JSON = getFileAsString(BASE_FILE_PATH + "/authentication/404_bad_local_id.json");
     private static final String ERROR_404_BAD_GLOBAL_ID_RESPONSE_JSON = getFileAsString(BASE_FILE_PATH + "/authentication/404_bad_global_id.json");
     private static final String ERROR_400_BAD_IDENTITY_PROVIDER_ID_RESPONSE_JSON = getFileAsString(BASE_FILE_PATH + "/authentication/400_invalid_identity_provider_id.json");
+    private static final String ERROR_404_LOCAL_ID_NOT_FOUND_RESPONSE_JSON = getFileAsString(BASE_FILE_PATH + "/device/404_local_id_not_found.json");
 
     private static final String NEW_DEVICE_HISTORY_RESPONSE_JSON = getFileAsString(BASE_FILE_PATH + "/history/empty_history_response.json");
     private static final String INITIAL_ADD_IDP_DEVICE_HISTORY_RESPONSE_JSON = getFileAsString(BASE_FILE_PATH + "/history/initial_add_idp_response.json");
@@ -147,6 +148,14 @@ public class PublisherIntegrationTest extends BaseHttpTest {
     }
 
     @Test
+    public void relateDeviceBeforeRegisteringLocalId() {
+        String publisherALocalId = "local-id-publisher-a-" + UUID.randomUUID().toString();
+
+        deviceTestUtil.relateDeviceToPublisherError(HttpStatus.SC_NOT_FOUND, publisherALocalId, publisherA.getCode(), null, ERROR_404_LOCAL_ID_NOT_FOUND_RESPONSE_JSON);
+
+    }
+
+    @Test
     public void existingDeviceDeletePublisherLocalId() {
         String publisherAFirstLocalId = "local-id-publisher-a-" + UUID.randomUUID().toString();
         deviceTestUtil.registerLocalId(publisherAFirstLocalId, publisherA.getToken());
@@ -178,7 +187,11 @@ public class PublisherIntegrationTest extends BaseHttpTest {
         // Ensure the system resolved to the same global ID each time
         assertEquals(firstGlobalId, secondGlobalId);
 
-        // Try passing in the same local ID but this time with a different publisher
+        // Try passing in the same local ID but this time with a different publisher without registering it
+        deviceTestUtil.relateDeviceToPublisherError(HttpStatus.SC_NOT_FOUND, publisherALocalId, publisherB.getCode(), null, ERROR_404_LOCAL_ID_NOT_FOUND_RESPONSE_JSON);
+
+        deviceTestUtil.registerLocalId(publisherALocalId, publisherB.getToken());
+
         String thirdGlobalId = deviceTestUtil.relateDeviceToPublisher(publisherALocalId, publisherB.getCode(), null, RELATE_NEW_DEVICE_PUBLISHER_A_RESPONSE_JSON);
 
         // Test that the system did not resolve to the same device because this was for a different publisher

--- a/src/test/java/com/atypon/wayf/integration/publisher/PublisherIntegrationTest.java
+++ b/src/test/java/com/atypon/wayf/integration/publisher/PublisherIntegrationTest.java
@@ -16,6 +16,8 @@
 
 package com.atypon.wayf.integration.publisher;
 
+import com.atypon.wayf.data.publisher.Publisher;
+import com.atypon.wayf.integration.HttpTestUtil;
 import com.atypon.wayf.request.ResponseWriter;
 import com.atypon.wayf.verticle.routing.BaseHttpTest;
 import org.apache.http.HttpStatus;
@@ -61,8 +63,8 @@ public class PublisherIntegrationTest extends BaseHttpTest {
     private static final String RE_ADD_SAML_IDP_HISTORY_RESPONSE_JSON = getFileAsString(BASE_FILE_PATH + "/history/re-add_saml_idp_response.json");
     private static final String ONE_OATH_HISTORY_RESPONSE_JSON = getFileAsString(BASE_FILE_PATH + "/history/one_oath_response.json");
 
-    private String publisherAToken;
-    private String publisherBToken;
+    private Publisher publisherA;
+    private Publisher publisherB;
 
     public PublisherIntegrationTest() {
         super(HTTP_LOGGING_FILE);
@@ -70,10 +72,16 @@ public class PublisherIntegrationTest extends BaseHttpTest {
 
     @Before
     public void createPublishers() {
-        if (publisherAToken == null) {
+        if (publisherA  == null) {
             // Create 2 Publishers
-            publisherAToken = publisherTestUtil.testCreatePublisher(CREATE_PUBLISHER_A_REQUEST_JSON, CREATE_PUBLISHER_A_RESPONSE_JSON);
-            publisherBToken = publisherTestUtil.testCreatePublisher(CREATE_PUBLISHER_B_REQUEST_JSON, CREATE_PUBLISHER_B_RESPONSE_JSON);
+            String publisherAJson = CREATE_PUBLISHER_A_REQUEST_JSON;
+            publisherAJson = HttpTestUtil.setField(publisherAJson, "code", "code-" + UUID.randomUUID().toString());
+
+            String publisherBJson = CREATE_PUBLISHER_B_REQUEST_JSON;
+            publisherBJson = HttpTestUtil.setField(publisherBJson, "code", "code-" + UUID.randomUUID().toString());
+
+            publisherA = publisherTestUtil.testCreatePublisher(publisherAJson, CREATE_PUBLISHER_A_RESPONSE_JSON);
+            publisherB = publisherTestUtil.testCreatePublisher(publisherBJson, CREATE_PUBLISHER_B_RESPONSE_JSON);
         }
     }
 
@@ -81,55 +89,58 @@ public class PublisherIntegrationTest extends BaseHttpTest {
     public void multiplePublisherFullFlow() throws Exception {
         String publisherALocalId = "local-id-publisher-a-" + UUID.randomUUID().toString();
 
+        deviceTestUtil.registerLocalId(publisherALocalId, publisherA.getToken());
+
         // Create device
-        String globalIdPublisherA = deviceTestUtil.relateDeviceToPublisher(publisherALocalId, publisherAToken, null, RELATE_NEW_DEVICE_PUBLISHER_A_RESPONSE_JSON);
+        String globalIdPublisherA = deviceTestUtil.relateDeviceToPublisher(publisherALocalId, publisherA.getCode(), null, RELATE_NEW_DEVICE_PUBLISHER_A_RESPONSE_JSON);
 
         // Assert an empty history
-        deviceAccessTestUtil.testDeviceHistory(publisherALocalId, publisherAToken, NEW_DEVICE_HISTORY_RESPONSE_JSON);
+        deviceAccessTestUtil.testDeviceHistory(publisherALocalId, publisherA.getToken(), NEW_DEVICE_HISTORY_RESPONSE_JSON);
 
         // Get the minimum last active date
         Date earliestLastActiveDate = DATE_FORMAT.parse(DATE_FORMAT.format(new Date()));
 
         // Add the IDPs to the device multiple times and validate the IDP's ID is the same each time
-        Long samlId = identityProviderTestUtil.testAddIdpToDeviceAndIdpResolution(5, publisherALocalId, publisherAToken, CREATE_SAML_IDP_REQUEST_JSON, CREATE_SAML_IDP_RESPONSE_JSON);
-        identityProviderTestUtil.testAddIdpToDeviceAndIdpResolution(4, publisherALocalId, publisherAToken, CREATE_OPEN_ATHENS_IDP_REQUEST_JSON, CREATE_OPEN_ATHENS_IDP_RESPONSE_JSON);
-        identityProviderTestUtil.testAddIdpToDeviceAndIdpResolution(3, publisherALocalId, publisherAToken, CREATE_OAUTH_IDP_REQUEST_JSON, CREATE_OAUTH_IDP_RESPONSE_JSON);
+        Long samlId = identityProviderTestUtil.testAddIdpToDeviceAndIdpResolution(5, publisherALocalId, publisherA.getToken(), CREATE_SAML_IDP_REQUEST_JSON, CREATE_SAML_IDP_RESPONSE_JSON);
+        identityProviderTestUtil.testAddIdpToDeviceAndIdpResolution(4, publisherALocalId, publisherA.getToken(), CREATE_OPEN_ATHENS_IDP_REQUEST_JSON, CREATE_OPEN_ATHENS_IDP_RESPONSE_JSON);
+        identityProviderTestUtil.testAddIdpToDeviceAndIdpResolution(3, publisherALocalId, publisherA.getToken(), CREATE_OAUTH_IDP_REQUEST_JSON, CREATE_OAUTH_IDP_RESPONSE_JSON);
 
         // Get the maximum last active active date
         Date latestLastActiveDate = ResponseWriter.DATE_FORMAT.parse(DATE_FORMAT.format(new Date()));
 
         // Test the device history after adding the IDPs
-        String deviceHistoryFromPublisherA = deviceAccessTestUtil.testDeviceHistory(publisherALocalId, publisherAToken, INITIAL_ADD_IDP_DEVICE_HISTORY_RESPONSE_JSON);
+        String deviceHistoryFromPublisherA = deviceAccessTestUtil.testDeviceHistory(publisherALocalId, publisherA.getToken(), INITIAL_ADD_IDP_DEVICE_HISTORY_RESPONSE_JSON);
         deviceAccessTestUtil.testLastActiveDateBetween(earliestLastActiveDate, latestLastActiveDate, 3, deviceHistoryFromPublisherA);
 
         // Relate the device to publisher B
         String publisherBLocalId = "local-id-publisher-b-" + UUID.randomUUID().toString();
-        String globalIdPublisherB = deviceTestUtil.relateDeviceToPublisher(publisherBLocalId, publisherBToken, globalIdPublisherA, RELATE_NEW_DEVICE_PUBLISHER_A_RESPONSE_JSON);
+        deviceTestUtil.registerLocalId(publisherBLocalId, publisherB.getToken());
+        String globalIdPublisherB = deviceTestUtil.relateDeviceToPublisher(publisherBLocalId, publisherB.getCode(), globalIdPublisherA, RELATE_NEW_DEVICE_PUBLISHER_A_RESPONSE_JSON);
 
         assertEquals(globalIdPublisherA, globalIdPublisherB);
 
         // Get the usage history for publisher B
-        String deviceHistoryFromPublisherB = deviceAccessTestUtil.testDeviceHistory(publisherBLocalId, publisherBToken, INITIAL_ADD_IDP_DEVICE_HISTORY_RESPONSE_JSON);
+        String deviceHistoryFromPublisherB = deviceAccessTestUtil.testDeviceHistory(publisherBLocalId, publisherB.getToken(), INITIAL_ADD_IDP_DEVICE_HISTORY_RESPONSE_JSON);
 
         // Compare the usage history from publisher A to that of publisher B
         deviceAccessTestUtil.compareDeviceHistory(deviceHistoryFromPublisherA, deviceHistoryFromPublisherB);
 
         // Remove the SAML entity from the device from publisher A
-        identityProviderTestUtil.removeIdpForDevice(publisherALocalId, publisherAToken, samlId);
+        identityProviderTestUtil.removeIdpForDevice(publisherALocalId, publisherA.getToken(), samlId);
 
         // Get the usage history as publisher A and then publisher B
-        deviceHistoryFromPublisherA = deviceAccessTestUtil.testDeviceHistory(publisherALocalId, publisherAToken, AFTER_DELETE_IDP_DEVICE_HISTORY_RESPONSE_JSON);
-        deviceHistoryFromPublisherB = deviceAccessTestUtil.testDeviceHistory(publisherBLocalId, publisherBToken, AFTER_DELETE_IDP_DEVICE_HISTORY_RESPONSE_JSON);
+        deviceHistoryFromPublisherA = deviceAccessTestUtil.testDeviceHistory(publisherALocalId, publisherA.getToken(), AFTER_DELETE_IDP_DEVICE_HISTORY_RESPONSE_JSON);
+        deviceHistoryFromPublisherB = deviceAccessTestUtil.testDeviceHistory(publisherBLocalId, publisherB.getToken(), AFTER_DELETE_IDP_DEVICE_HISTORY_RESPONSE_JSON);
 
         // Ensure the usage history is the same for both publishers
         deviceAccessTestUtil.compareDeviceHistory(deviceHistoryFromPublisherA, deviceHistoryFromPublisherB);
 
         // Add back the SAML identity to the device
-        identityProviderTestUtil.testAddIdpToDeviceAndIdpResolution(5, publisherALocalId, publisherAToken, CREATE_SAML_IDP_REQUEST_JSON, CREATE_SAML_IDP_RESPONSE_JSON);
+        identityProviderTestUtil.testAddIdpToDeviceAndIdpResolution(5, publisherALocalId, publisherA.getToken(), CREATE_SAML_IDP_REQUEST_JSON, CREATE_SAML_IDP_RESPONSE_JSON);
 
         // Get the usage history as publisher A and then publisher B
-        deviceHistoryFromPublisherA = deviceAccessTestUtil.testDeviceHistory(publisherALocalId, publisherAToken, RE_ADD_SAML_IDP_HISTORY_RESPONSE_JSON);
-        deviceHistoryFromPublisherB = deviceAccessTestUtil.testDeviceHistory(publisherBLocalId, publisherBToken, RE_ADD_SAML_IDP_HISTORY_RESPONSE_JSON);
+        deviceHistoryFromPublisherA = deviceAccessTestUtil.testDeviceHistory(publisherALocalId, publisherA.getToken(), RE_ADD_SAML_IDP_HISTORY_RESPONSE_JSON);
+        deviceHistoryFromPublisherB = deviceAccessTestUtil.testDeviceHistory(publisherBLocalId, publisherB.getToken(), RE_ADD_SAML_IDP_HISTORY_RESPONSE_JSON);
 
         // Ensure the usage history is the same for both publishers
         deviceAccessTestUtil.compareDeviceHistory(deviceHistoryFromPublisherA, deviceHistoryFromPublisherB);
@@ -138,15 +149,17 @@ public class PublisherIntegrationTest extends BaseHttpTest {
     @Test
     public void existingDeviceDeletePublisherLocalId() {
         String publisherAFirstLocalId = "local-id-publisher-a-" + UUID.randomUUID().toString();
+        deviceTestUtil.registerLocalId(publisherAFirstLocalId, publisherA.getToken());
 
         // Create device
-        String firstGlobalId = deviceTestUtil.relateDeviceToPublisher(publisherAFirstLocalId, publisherAToken, null, RELATE_NEW_DEVICE_PUBLISHER_A_RESPONSE_JSON);
+        String firstGlobalId = deviceTestUtil.relateDeviceToPublisher(publisherAFirstLocalId, publisherA.getCode(), null, RELATE_NEW_DEVICE_PUBLISHER_A_RESPONSE_JSON);
 
         String publisherASecondLocalId = "local-id-publisher-a-" + UUID.randomUUID().toString();
 
         assertFalse(publisherAFirstLocalId.equals(publisherASecondLocalId));
 
-        String secondGlobalId = deviceTestUtil.relateDeviceToPublisher(publisherASecondLocalId, publisherAToken, firstGlobalId, RELATE_NEW_DEVICE_PUBLISHER_A_RESPONSE_JSON);
+        deviceTestUtil.registerLocalId(publisherASecondLocalId, publisherA.getToken());
+        String secondGlobalId = deviceTestUtil.relateDeviceToPublisher(publisherASecondLocalId, publisherA.getCode(), firstGlobalId, RELATE_NEW_DEVICE_PUBLISHER_A_RESPONSE_JSON);
 
         assertEquals(firstGlobalId, secondGlobalId);
     }
@@ -154,59 +167,63 @@ public class PublisherIntegrationTest extends BaseHttpTest {
     @Test
     public void existingDeviceDeleteGlobalId() {
         String publisherALocalId = "local-id-publisher-a-" + UUID.randomUUID().toString();
+        deviceTestUtil.registerLocalId(publisherALocalId, publisherA.getToken());
 
         // Create device for local ID
-        String firstGlobalId = deviceTestUtil.relateDeviceToPublisher(publisherALocalId, publisherAToken, null, RELATE_NEW_DEVICE_PUBLISHER_A_RESPONSE_JSON);
+        String firstGlobalId = deviceTestUtil.relateDeviceToPublisher(publisherALocalId, publisherA.getCode(), null, RELATE_NEW_DEVICE_PUBLISHER_A_RESPONSE_JSON);
 
         // Create device again for same local ID but do not pass in global ID
-        String secondGlobalId = deviceTestUtil.relateDeviceToPublisher(publisherALocalId, publisherAToken, null, RELATE_NEW_DEVICE_PUBLISHER_A_RESPONSE_JSON);
+        String secondGlobalId = deviceTestUtil.relateDeviceToPublisher(publisherALocalId, publisherA.getCode(), null, RELATE_NEW_DEVICE_PUBLISHER_A_RESPONSE_JSON);
 
         // Ensure the system resolved to the same global ID each time
         assertEquals(firstGlobalId, secondGlobalId);
 
         // Try passing in the same local ID but this time with a different publisher
-        String thirdGlobalId = deviceTestUtil.relateDeviceToPublisher(publisherALocalId, publisherBToken, null, RELATE_NEW_DEVICE_PUBLISHER_A_RESPONSE_JSON);
+        String thirdGlobalId = deviceTestUtil.relateDeviceToPublisher(publisherALocalId, publisherB.getCode(), null, RELATE_NEW_DEVICE_PUBLISHER_A_RESPONSE_JSON);
 
         // Test that the system did not resolve to the same device because this was for a different publisher
-        assertNotNull(firstGlobalId, thirdGlobalId);
+        assertNotEquals(firstGlobalId, thirdGlobalId);
     }
 
     @Test
     public void nonUniqueLocalId() {
         // Generate Device X for Publisher A
         String publisherALocalId = "local-id-publisher-a-" + UUID.randomUUID().toString();
-        String deviceXGlobalId = deviceTestUtil.relateDeviceToPublisher(publisherALocalId, publisherAToken, null, RELATE_NEW_DEVICE_PUBLISHER_A_RESPONSE_JSON);
+        deviceTestUtil.registerLocalId(publisherALocalId, publisherA.getToken());
+        String deviceXGlobalId = deviceTestUtil.relateDeviceToPublisher(publisherALocalId, publisherA.getCode(), null, RELATE_NEW_DEVICE_PUBLISHER_A_RESPONSE_JSON);
 
         // Link Device X to Publisher B
         String publisherBDeviceXLocalId = "local-id-publisher-b-" + UUID.randomUUID().toString();
-        String deviceXGlobalIdPublisherB = deviceTestUtil.relateDeviceToPublisher(publisherBDeviceXLocalId, publisherBToken, deviceXGlobalId, RELATE_NEW_DEVICE_PUBLISHER_A_RESPONSE_JSON);
+        deviceTestUtil.registerLocalId(publisherBDeviceXLocalId, publisherB.getToken());
+        String deviceXGlobalIdPublisherB = deviceTestUtil.relateDeviceToPublisher(publisherBDeviceXLocalId, publisherB.getCode(), deviceXGlobalId, RELATE_NEW_DEVICE_PUBLISHER_A_RESPONSE_JSON);
 
         // Ensure same global ID
         assertEquals(deviceXGlobalId, deviceXGlobalIdPublisherB);
 
         // Assert an empty history
-        deviceAccessTestUtil.testDeviceHistory(publisherALocalId, publisherAToken, NEW_DEVICE_HISTORY_RESPONSE_JSON);
+        deviceAccessTestUtil.testDeviceHistory(publisherALocalId, publisherA.getToken(), NEW_DEVICE_HISTORY_RESPONSE_JSON);
 
         // Add activity to Device X
-        identityProviderTestUtil.testAddIdpToDeviceAndIdpResolution(1, publisherALocalId, publisherAToken, CREATE_OAUTH_IDP_REQUEST_JSON, CREATE_OAUTH_IDP_RESPONSE_JSON);
+        identityProviderTestUtil.testAddIdpToDeviceAndIdpResolution(1, publisherALocalId, publisherA.getToken(), CREATE_OAUTH_IDP_REQUEST_JSON, CREATE_OAUTH_IDP_RESPONSE_JSON);
 
-        deviceAccessTestUtil.testDeviceHistory(publisherALocalId, publisherAToken, ONE_OATH_HISTORY_RESPONSE_JSON);
+        deviceAccessTestUtil.testDeviceHistory(publisherALocalId, publisherA.getToken(), ONE_OATH_HISTORY_RESPONSE_JSON);
 
         // Generate Device Y under same local ID as Device X
         String publisherBSecondLocalId = "local-id-publisher-b-" + UUID.randomUUID().toString();
-        String deviceYGlobalId = deviceTestUtil.relateDeviceToPublisher(publisherBSecondLocalId, publisherBToken, null, RELATE_NEW_DEVICE_PUBLISHER_A_RESPONSE_JSON);
+        deviceTestUtil.registerLocalId(publisherBSecondLocalId, publisherB.getToken());
+        String deviceYGlobalId = deviceTestUtil.relateDeviceToPublisher(publisherBSecondLocalId, publisherB.getCode(), null, RELATE_NEW_DEVICE_PUBLISHER_A_RESPONSE_JSON);
 
         // Assert an empty history
-        deviceAccessTestUtil.testDeviceHistory(publisherBSecondLocalId, publisherBToken, NEW_DEVICE_HISTORY_RESPONSE_JSON);
+        deviceAccessTestUtil.testDeviceHistory(publisherBSecondLocalId, publisherB.getToken(), NEW_DEVICE_HISTORY_RESPONSE_JSON);
 
         // Overwrite Device X with Device Y for publisher A's localId
-        String deviceYGlobalIdSecond = deviceTestUtil.relateDeviceToPublisher(publisherALocalId, publisherAToken, deviceYGlobalId, RELATE_NEW_DEVICE_PUBLISHER_A_RESPONSE_JSON);
+        String deviceYGlobalIdSecond = deviceTestUtil.relateDeviceToPublisher(publisherALocalId, publisherA.getCode(), deviceYGlobalId, RELATE_NEW_DEVICE_PUBLISHER_A_RESPONSE_JSON);
 
         // Test to ensure the localId now resolves to Device Y
-        deviceAccessTestUtil.testDeviceHistory(publisherALocalId, publisherAToken, NEW_DEVICE_HISTORY_RESPONSE_JSON);
+        deviceAccessTestUtil.testDeviceHistory(publisherALocalId, publisherA.getToken(), NEW_DEVICE_HISTORY_RESPONSE_JSON);
 
         // Test to make sure Device X still has data for publisher B
-        deviceAccessTestUtil.testDeviceHistory(publisherBDeviceXLocalId, publisherBToken, ONE_OATH_HISTORY_RESPONSE_JSON);
+        deviceAccessTestUtil.testDeviceHistory(publisherBDeviceXLocalId, publisherB.getToken(), ONE_OATH_HISTORY_RESPONSE_JSON);
     }
 
     @Test
@@ -217,8 +234,9 @@ public class PublisherIntegrationTest extends BaseHttpTest {
         String badToken = "obviously-bad-token";
         deviceTestUtil.deviceQueryBadPublisherToken(publisherALocalId, badToken, ERROR_401_RESPONSE_JSON);
 
+        deviceTestUtil.registerLocalId(publisherALocalId, publisherA.getToken());
         // Create device
-        deviceTestUtil.relateDeviceToPublisher(publisherALocalId, publisherAToken, null, RELATE_NEW_DEVICE_PUBLISHER_A_RESPONSE_JSON);
+        deviceTestUtil.relateDeviceToPublisher(publisherALocalId, publisherA.getCode(), null, RELATE_NEW_DEVICE_PUBLISHER_A_RESPONSE_JSON);
 
         // Read History with bad token
         deviceAccessTestUtil.testDeviceHistoryError(HttpStatus.SC_UNAUTHORIZED, publisherALocalId, badToken, ERROR_401_RESPONSE_JSON);
@@ -226,7 +244,7 @@ public class PublisherIntegrationTest extends BaseHttpTest {
         // Test adding an IDP with a bad token
         identityProviderTestUtil.addIdpToDeviceError(HttpStatus.SC_UNAUTHORIZED, publisherALocalId, badToken, CREATE_OAUTH_IDP_REQUEST_JSON, ERROR_401_RESPONSE_JSON);
 
-        Long samlId = identityProviderTestUtil.testAddIdpToDeviceAndIdpResolution(1, publisherALocalId, publisherAToken, CREATE_SAML_IDP_REQUEST_JSON, CREATE_SAML_IDP_RESPONSE_JSON);
+        Long samlId = identityProviderTestUtil.testAddIdpToDeviceAndIdpResolution(1, publisherALocalId, publisherA.getToken(), CREATE_SAML_IDP_REQUEST_JSON, CREATE_SAML_IDP_RESPONSE_JSON);
 
         // Test removing IDP with bad token
         identityProviderTestUtil.removeIdpForDeviceError(HttpStatus.SC_UNAUTHORIZED, publisherALocalId, badToken, samlId, ERROR_401_RESPONSE_JSON);
@@ -236,25 +254,28 @@ public class PublisherIntegrationTest extends BaseHttpTest {
     public void badLocalId() {
         String publisherALocalId = "local-id-publisher-a-" + UUID.randomUUID().toString();
 
-        deviceTestUtil.relateDeviceToPublisher(publisherALocalId, publisherAToken, null, RELATE_NEW_DEVICE_PUBLISHER_A_RESPONSE_JSON);
+        deviceTestUtil.registerLocalId(publisherALocalId, publisherA.getToken());
+        deviceTestUtil.relateDeviceToPublisher(publisherALocalId, publisherA.getCode(), null, RELATE_NEW_DEVICE_PUBLISHER_A_RESPONSE_JSON);
 
         String badLocalId = "obviously-bad-local-id";
-        deviceAccessTestUtil.testDeviceHistoryError(HttpStatus.SC_NOT_FOUND, badLocalId, publisherAToken, ERROR_404_BAD_LOCAL_ID_RESPONSE_JSON);
+        deviceAccessTestUtil.testDeviceHistoryError(HttpStatus.SC_NOT_FOUND, badLocalId, publisherA.getToken(), ERROR_404_BAD_LOCAL_ID_RESPONSE_JSON);
 
-        identityProviderTestUtil.addIdpToDeviceError(HttpStatus.SC_NOT_FOUND, badLocalId, publisherAToken, CREATE_OAUTH_IDP_REQUEST_JSON, ERROR_404_BAD_LOCAL_ID_RESPONSE_JSON);
+        identityProviderTestUtil.addIdpToDeviceError(HttpStatus.SC_NOT_FOUND, badLocalId, publisherA.getToken(), CREATE_OAUTH_IDP_REQUEST_JSON, ERROR_404_BAD_LOCAL_ID_RESPONSE_JSON);
 
-        Long samlId = identityProviderTestUtil.testAddIdpToDeviceAndIdpResolution(1, publisherALocalId, publisherAToken, CREATE_SAML_IDP_REQUEST_JSON, CREATE_SAML_IDP_RESPONSE_JSON);
+        Long samlId = identityProviderTestUtil.testAddIdpToDeviceAndIdpResolution(1, publisherALocalId, publisherA.getToken(), CREATE_SAML_IDP_REQUEST_JSON, CREATE_SAML_IDP_RESPONSE_JSON);
 
-        identityProviderTestUtil.removeIdpForDeviceError(HttpStatus.SC_NOT_FOUND, badLocalId, publisherAToken, samlId, ERROR_404_BAD_LOCAL_ID_RESPONSE_JSON);
+        identityProviderTestUtil.removeIdpForDeviceError(HttpStatus.SC_NOT_FOUND, badLocalId, publisherA.getToken(), samlId, ERROR_404_BAD_LOCAL_ID_RESPONSE_JSON);
     }
 
     @Test
     public void badIdentityProviderId() {
         String publisherALocalId = "local-id-publisher-a-" + UUID.randomUUID().toString();
-        deviceTestUtil.relateDeviceToPublisher(publisherALocalId, publisherAToken, null, RELATE_NEW_DEVICE_PUBLISHER_A_RESPONSE_JSON);
 
-        identityProviderTestUtil.testAddIdpToDeviceAndIdpResolution(1, publisherALocalId, publisherAToken, CREATE_SAML_IDP_REQUEST_JSON, CREATE_SAML_IDP_RESPONSE_JSON);
-        identityProviderTestUtil.removeIdpForDeviceError(HttpStatus.SC_BAD_REQUEST, publisherALocalId, publisherAToken, 0L, ERROR_400_BAD_IDENTITY_PROVIDER_ID_RESPONSE_JSON);
+        deviceTestUtil.registerLocalId(publisherALocalId, publisherA.getToken());
+        deviceTestUtil.relateDeviceToPublisher(publisherALocalId, publisherA.getCode(), null, RELATE_NEW_DEVICE_PUBLISHER_A_RESPONSE_JSON);
+
+        identityProviderTestUtil.testAddIdpToDeviceAndIdpResolution(1, publisherALocalId, publisherA.getToken(), CREATE_SAML_IDP_REQUEST_JSON, CREATE_SAML_IDP_RESPONSE_JSON);
+        identityProviderTestUtil.removeIdpForDeviceError(HttpStatus.SC_BAD_REQUEST, publisherALocalId, publisherA.getToken(), 0L, ERROR_400_BAD_IDENTITY_PROVIDER_ID_RESPONSE_JSON);
     }
 
     @Test
@@ -262,6 +283,7 @@ public class PublisherIntegrationTest extends BaseHttpTest {
         String badGlobalId = "obviously-bad-global-id";
         String publisherALocalId = "local-id-publisher-a-" + UUID.randomUUID().toString();
 
-        deviceTestUtil.relateDeviceToPublisherError(HttpStatus.SC_NOT_FOUND, publisherALocalId, publisherAToken, badGlobalId, ERROR_404_BAD_GLOBAL_ID_RESPONSE_JSON);
+        deviceTestUtil.registerLocalId(publisherALocalId, publisherA.getToken());
+        deviceTestUtil.relateDeviceToPublisherError(HttpStatus.SC_NOT_FOUND, publisherALocalId, publisherA.getCode(), badGlobalId, ERROR_404_BAD_GLOBAL_ID_RESPONSE_JSON);
     }
 }

--- a/src/test/resources/create_wayf_tables.sql
+++ b/src/test/resources/create_wayf_tables.sql
@@ -118,7 +118,7 @@ CREATE TABLE `publisher_local_id_device_xref` (
   `unique_publisher_key` VARCHAR (150),
   `publisher_id` int(11) NOT NULL,
   `local_id` VARCHAR(100) NOT NULL,
-  `device_id` int(11) NOT NULL,
+  `device_id` int(11) NULL,
   `created_date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `modified_date` timestamp NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (`unique_publisher_key`)

--- a/src/test/resources/json_files/publisher_device_integration/device/404_local_id_not_found.json
+++ b/src/test/resources/json_files/publisher_device_integration/device/404_local_id_not_found.json
@@ -1,0 +1,1 @@
+{"message":"Could not find local ID"}


### PR DESCRIPTION
- Added a new endpoint to force the publish to register a local ID with the cloud
- The client may now use the local ID by passing a JWT with the publisher's code
- Support for different types of authorization headers
- Existing test cases fixed