### PR TITLE
send event on XMLHttpRequest.DONE

### DIFF
--- a/src/main/resources/wayf_widget_template.js
+++ b/src/main/resources/wayf_widget_template.js
@@ -23,13 +23,15 @@ const LOCAL_ID_COOKIE_NAME = "wayf-local";
 
 function registerLocalId(localId) {
     var url = buildRegisterDeviceURL(localId);
-
     var request = new XMLHttpRequest();
+
     request.open("PATCH", url, true);
     request.setRequestHeader(AUTHORIZATION_HEADER_KEY, AUTHORIZATION_HEADER_VALUE);
     request.withCredentials = true;
     request.onreadystatechange = function() {
         if (request.readyState === XMLHttpRequest.DONE) {
+            let event = new Event('wayf-done');
+            document.dispatchEvent(event);
             if (request.status > 299) {
                 console.log(request.status + " " + request.responseText);
 


### PR DESCRIPTION
There is a scenario where we need to 'notify' other client JS that the widget finished sending the request to the WAYF Cloud. 
I am therefore creating  a custom event,  'wayf-done',  when XMLHttpRequest is DONE so that other the client JS can add a listener to it and handle it as appropriate.